### PR TITLE
fix client crash on backup policies with number content

### DIFF
--- a/ui/src/components/fields/FieldBase.tsx
+++ b/ui/src/components/fields/FieldBase.tsx
@@ -115,6 +115,7 @@ export default abstract class FieldBase {
         if (value === undefined || value === null) {
             return "";
         }
+        value = String(value);
         if (value.indexOf("\n") !== -1) {
             value = value.substring(0, value.indexOf("\n")) + "...";
         }


### PR DESCRIPTION
for example if "retention.daily" value is set (which is a number), it causes this crash:

console.js:288 TypeError: n.indexOf is not a function
    at Sd.getDisplayValue (FieldBase.tsx:118:27)
    at FieldObject.tsx:70:72
    at Array.map (<anonymous>)
    at gd.getDisplayValue (FieldObject.tsx:68:17)
    at Ed.createDisplayValue (FieldFactory.tsx:105:12)
    at Table.tsx:154:62
    at Array.map (<anonymous>)
    at Table.tsx:121:29
    at Array.map (<anonymous>)
    at ep (Table.tsx:118:42)