### PR TITLE
Helm chart: Allow setting an ingress class name

### DIFF
--- a/charts/nuodbaas-webui/README.md
+++ b/charts/nuodbaas-webui/README.md
@@ -18,6 +18,7 @@ All configurable parameters for each top-level scope are detailed below, organiz
 | `nuodbaasWebui.image.repository` | NuoDBaaS WebUI container image repository |`253548315642.dkr.ecr.us-east-1.amazonaws.com/nuodbaas-webui-docker`|
 | `nuodbaasWebui.image.pullPolicy` | NuoDBaaS WebUI container pull policy |`IfNotPresent`|
 | `nuodbaasWebui.image.pullSecrets` | Specify docker-registry secret names as an array | `[]` |
+| `nuodbaasWebui.ingress.className` | Class name of the ingress to use | `""` |
 | `nuodbaasWebui.resources.limits.cpu` | Specify cpu limit | `100m` |
 | `nuodbaasWebui.resources.limits.memory` | Specify memory limit | `128Mi` |
 | `nuodbaasWebui.resources.requests.cpu` | Specify cpu requests | `100m` |

--- a/charts/nuodbaas-webui/templates/ingress.yaml
+++ b/charts/nuodbaas-webui/templates/ingress.yaml
@@ -7,6 +7,9 @@ metadata:
   labels:
     {{- include "nuodbaas-webui.labels" . | nindent 4 }}
 spec:
+  {{- if .Values.nuodbaasWebui.ingress.className }}
+  ingressClassName: {{ .Values.nuodbaasWebui.ingress.className }}
+  {{- end }}
   rules:
     - http:
         paths:

--- a/charts/nuodbaas-webui/values.yaml
+++ b/charts/nuodbaas-webui/values.yaml
@@ -21,4 +21,5 @@ nuodbaasWebui:
     pathPrefix: ui
     hosts:
       - nuodbaas-webui.local
+    className: ""
   cpUrl: /nuodb-cp


### PR DESCRIPTION
Add a helm value to override the ingress class.

It is needed for our Outscale deployment since our services use NGinx and not the default HAProxy.