### PR TITLE
remove obsolete "-dev.sha" prefix (deployment fix)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,7 +102,7 @@ jobs:
           command: |
             VERSION=$(grep -e "^appVersion:" charts/nuodbaas-webui/Chart.yaml | cut -d \" -f 2 | cut -d - -f 1)
             SHA=$(git rev-parse --short HEAD)
-            VERSION_SHA=${VERSION}-dev.sha-${SHA}
+            VERSION_SHA=${VERSION}-${SHA}
 
             mkdir -p tmp/repos/$DBAAS_DEPLOY_REPO \
               && cd tmp/repos/$DBAAS_DEPLOY_REPO

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ KUBECTL := bin/kubectl
 IMG_REPO := nuodbaas-webui
 VERSION := $(shell grep -e "^appVersion:" charts/nuodbaas-webui/Chart.yaml | cut -d \" -f 2 | cut -d - -f 1)
 SHA := $(shell git rev-parse --short HEAD)
-VERSION_SHA ?= ${VERSION}-dev.sha-${SHA}
+VERSION_SHA ?= ${VERSION}-${SHA}
 UNCOMMITTED := $(shell rm -f get_helm.sh && git status --porcelain)
 
 # The help target prints out all targets with their descriptions organized


### PR DESCRIPTION
when deploying the docker image, it pulls from "ghcr.io/nuodb/nuodbaas-webui:1.0.0-dev.sha-3570472" instead of "ghcr.io/nuodb/nuodbaas-webui:1.0.0-3570472"