### PR TITLE
make table row popup menu stick to the right of the viewport

### DIFF
--- a/selenium-tests/src/test/java/com/nuodb/selenium/TestRoutines.java
+++ b/selenium-tests/src/test/java/com/nuodb/selenium/TestRoutines.java
@@ -132,8 +132,8 @@ public class TestRoutines extends SeleniumTestHelper {
         List<WebElement> menuToggles = element.findElements(By.xpath("div[@data-testid='menu-toggle']"));
         assertEquals(1, menuToggles.size());
         menuToggles.get(0).click();
-        WebElement parent = menuToggles.get(0).findElement(By.xpath(".."));
-        List<WebElement> menuItems = parent.findElements(By.xpath(".//div[@data-testid='" + dataTestId + "']"));
+        WebElement menuPopup = getElement("menu-popup");
+        List<WebElement> menuItems = menuPopup.findElements(By.xpath(".//div[@data-testid='" + dataTestId + "']"));
         assertEquals(1, menuItems.size());
         menuItems.get(0).click();
     }

--- a/ui/public/theme/base.css
+++ b/ui/public/theme/base.css
@@ -40,6 +40,9 @@
 }
 
 .NuoMenuPopupItem {
+    display: flex;
+        flex-direction: row;
+        justify-content: space-between;
     margin: 0px;
     padding: 5px 10px;
     font-family: Roboto, Helvetica, Arial, sans-serif;
@@ -52,6 +55,11 @@
     white-space: nowrap;
 }
 
+.NuoMenuPopupItem>svg {
+    display: flex;
+    flex: 0 0 auto;
+    opacity: 0.5;
+}
 .NuoMenuPopupItem:hover {
     background-color: lightgray;
 }
@@ -68,4 +76,93 @@
 .NuoTableNoData {
     font-size: 1.25em;
     padding: 25px;
+}
+.NuoTableContainer {
+    box-shadow: 0px 2px 1px -1px rgba(0, 0, 0, 0.2), 0px 1px 1px 0px rgba(0, 0, 0, 0.14), 0px 1px 3px 0px rgba(0, 0, 0, 0.12);
+    background-color: #fff;
+    color: rgba(0, 0, 0, 0.87);
+    -webkit-transition: box-shadow 300ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+    transition: box-shadow 300ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+    border-radius: 4px;
+    box-shadow: var(--Paper-shadow);
+    background-image: var(--Paper-overlay);
+    overflow: hidden;
+    width: 100%;
+    overflow-x: auto;
+}
+
+.NuoTableTable {
+    display: table;
+    width: 100%;
+    border-collapse: collapse;
+    border-spacing: 0;
+    text-indent: initial;
+    unicode-bidi: isolate;
+    border-color: gray;
+}
+
+.NuoTableThead {
+    vertical-align: middle;
+    unicode-bidi: isolate;
+    border-color: inherit;
+}
+
+.NuoTableTr {
+    color: inherit;
+    display: table-row;
+    vertical-align: middle;
+    outline: 0;
+    unicode-bidi: isolate;
+    border-color: inherit;
+}
+
+.NuoTableSettingsItem {
+    display: flex;
+    flex-direction: row;
+    flex: 1 1 auto;
+}
+
+.NuoTableSettingsItem>label {
+    display: flex;
+    flex: 1 1 auto;
+}
+
+.NuoTableTh,
+.NuoTableTd {
+    font-family: "Roboto", "Helvetica", "Arial", sans-serif;
+    font-size: 0.875rem;
+    letter-spacing: 0.0108em;
+    display: table-cell;
+    padding: 16px;
+    vertical-align: inherit;
+    border-bottom: 1px solid rgba(224, 224, 224, 1);
+    color: rgba(0, 0, 0, 0.87);
+    unicode-bidi: isolate;
+    text-align: left;
+}
+
+.NuoTableTh {
+    line-height: 1.5rem;
+    font-weight: 500;
+}
+
+.NuoTableTd {
+    font-weight: 400;
+    line-height: 1.43;
+}
+
+.NuoTableTbody {
+    display: table-row-group;
+    vertical-align: middle;
+    unicode-bidi: isolate;
+    border-color: inherit;
+    border-collapse: collapse;
+    border-spacing: 0;
+}
+
+.NuoTableMenuCell {
+    position: sticky;
+    right: 0;
+    background-color: rgba(255, 255, 255, 0.8);
+    ;
 }

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -19,6 +19,7 @@ import GlobalErrorBoundary from "./components/GlobalErrorBoundary";
 import Auth from "./utils/auth";
 import Settings from './components/pages/Settings';
 import Customizations from './utils/Customizations';
+import { PopupMenu } from './components/controls/Menu';
 
 /**
  * React Root Application. Sets up dialogs, BrowserRouter and Schema from Control Plane
@@ -32,6 +33,7 @@ export default function App() {
       <GlobalErrorBoundary>
         <Customizations>
           <CssBaseline />
+          <PopupMenu />
           <Dialog />
           <BrowserRouter>
             {isLoggedIn

--- a/ui/src/components/controls/Menu.tsx
+++ b/ui/src/components/controls/Menu.tsx
@@ -31,7 +31,7 @@ export default function Menu(props: MenuProps): JSX.Element {
 
     if (children) {
         return <>
-            <div onClick={(event) => {
+            <div data-testid="menu-toggle" onClick={(event) => {
                 PopupMenu.showMenu(props, event.currentTarget)
             }}>
                 <>{children}</>
@@ -164,7 +164,6 @@ export class PopupMenu extends Component<{}, PopupState> {
         const rect = anchor.getBoundingClientRect();
         const x = this.state.align === "right" ? rect?.right : rect?.left;
         return <div
-            data-testid="menu-toggle"
             style={{
                 justifyContent: this.state.align === "left" ? "start" : "end",
                 position: "fixed",
@@ -178,7 +177,7 @@ export class PopupMenu extends Component<{}, PopupState> {
             className="NuoMenuToggle"
             onClick={() => this.setState({ anchor: null })}>
             <div style={{ position: "fixed", right: x, left: x, top: rect?.bottom, bottom: rect?.bottom, zIndex: 102 }}>
-                <div id="NuoMenuPopup" className={"NuoMenuPopup " + (this.state.align === "right" ? " NuoAlignRight" : " NuoAlignLeft")}>
+                <div id="NuoMenuPopup" data-testid="menu-popup" className={"NuoMenuPopup " + (this.state.align === "right" ? " NuoAlignRight" : " NuoAlignLeft")}>
                     {this.state.items.map((item: MenuItemProps) => <div style={{ zIndex: 102 }}
                         id={item.id}
                         data-testid={item["data-testid"]}

--- a/ui/src/components/controls/Menu.tsx
+++ b/ui/src/components/controls/Menu.tsx
@@ -1,101 +1,18 @@
 // (C) Copyright 2024 Dassault Systemes SE.  All Rights Reserved.
 
-import { useState } from 'react';
+import { Component, useEffect } from 'react';
 import Button from './Button';
 
 import MoreVertIcon from '@mui/icons-material/MoreVert';
+import DragHandleIcon from '@mui/icons-material/DragHandle';
 import { MenuItemProps, MenuProps } from '../../utils/types';
 
 export default function Menu(props: MenuProps): JSX.Element {
-    const { align, popup, items, setItems, className, draggable } = props;
-    const [anchor, setAnchor] = useState<Element | null>(null);
-    const [dndSelected, setDndSelected] = useState();
+    const { popupId, items, className } = props;
 
-    function dndIsBefore(el1: any, el2: any) {
-        let cur
-        if (el2.parentNode === el1.parentNode) {
-            for (cur = el1.previousSibling; cur; cur = cur.previousSibling) {
-                if (cur === el2) return true
-            }
-        }
-        return false;
-    }
-
-    /* find given element target (or parent) which is draggable */
-    function dndGetDraggableTarget(target: any) {
-        while (target.getAttribute("draggable") !== "true") {
-            if (!target.parentElement) {
-                return undefined;
-            }
-            target = target.parentElement;
-        }
-        return target;
-    }
-
-    function dndOver(e: React.DragEvent<HTMLDivElement>) {
-        e.preventDefault();
-        const draggableTarget = dndGetDraggableTarget(e.target);
-        if (!draggableTarget || !draggableTarget.parentNode) {
-            return;
-        }
-
-        if (dndIsBefore(dndSelected, draggableTarget)) {
-            draggableTarget.parentNode.insertBefore(dndSelected, draggableTarget)
-        } else {
-            draggableTarget.parentNode.insertBefore(dndSelected, draggableTarget.nextSibling)
-        }
-    }
-
-    function dndDrop(e: React.DragEvent<HTMLDivElement>) {
-        setDndSelected(undefined);
-        const target = dndGetDraggableTarget(e.target);
-        if (!target?.parentNode?.children) {
-            return;
-        }
-        let newItems: MenuItemProps[] = [];
-        Array.from(target.parentNode.children).forEach((child: any) => {
-            const newItem = items.find(item => item.id === child.getAttribute("id"));
-            newItem && newItems.push(newItem);
-        })
-        if (setItems) {
-            setItems(newItems);
-        }
-    }
-
-    function dndStart(e: any) {
-        const draggableTarget = dndGetDraggableTarget(e.target);
-        if (!draggableTarget) {
-            return;
-        }
-
-        e.dataTransfer.effectAllowed = 'move'
-        e.dataTransfer.setData('text', draggableTarget.getAttribute("id"))
-        setDndSelected(e.target);
-    }
-
-    function popupMenu(items: MenuItemProps[]) {
-        const rect = anchor?.getBoundingClientRect();
-        const x = align === "right" ? rect?.right : rect?.left;
-        return <div
-            style={{ display: anchor ? "block" : "none", position: "fixed", right: 0, left: 0, top: 0, bottom: 0, backgroundColor: "transparent", zIndex: 1 }}
-            onClick={() => setAnchor(null)}>
-            <div style={{ position: "fixed", right: x, left: x, top: rect?.bottom, bottom: rect?.bottom, zIndex: 2 }}>
-                <div id="NuoMenuPopup" className={"NuoMenuPopup " + (align === "right" ? " NuoAlignRight" : " NuoAlignLeft")}>
-                    {items.map(item => <div style={{ zIndex: 2 }}
-                        id={item.id}
-                        data-testid={item["data-testid"]}
-                        draggable={draggable}
-                        onDrop={dndDrop}
-                        onDragOver={dndOver}
-                        onDragStart={dndStart}
-                        key={item.id}
-                        className="NuoMenuPopupItem"
-                        onClick={(e) => { e.stopPropagation(); setAnchor(null); item.onClick && item.onClick(); }}>
-                        {item.label}
-                    </div>)}
-                </div></div>
-        </div>;
-    }
+    useEffect(() => {
+        PopupMenu.updateMenu(props)
+    }, [props]);
 
     function listMenu(items: MenuItemProps[]) {
         return items.map((item, index) => <Button
@@ -108,21 +25,181 @@ export default function Menu(props: MenuProps): JSX.Element {
     }
 
     let { children } = props;
-    if (popup && !children) {
+    if (popupId && !children) {
         children = <MoreVertIcon />
     }
 
     if (children) {
         return <>
-            <div data-testid="menu-toggle" style={{ display: "flex", justifyContent: align === "left" ? "start" : "end" }} className="NuoMenuToggle" onClick={(event) => {
-                setAnchor(event.currentTarget)
+            <div onClick={(event) => {
+                PopupMenu.showMenu(props, event.currentTarget)
             }}>
                 <>{children}</>
             </div>
-            {popupMenu(items)}
         </>;
     }
     else {
         return <div className={className}>{listMenu(items)}</div>;
+    }
+}
+
+let s_popupInstance: PopupMenu | null = null;
+
+type AlignType = "right" | "left";
+
+interface PopupState extends MenuProps {
+    dndSelected: any;
+    anchor: Element | null;
+}
+
+export class PopupMenu extends Component<{}, PopupState> {
+    state = {
+        popupId: "",
+        items: [],
+        setItems: undefined,
+        anchor: null,
+        align: "right" as AlignType,
+        draggable: false,
+
+        dndSelected: undefined
+    }
+
+    componentDidMount() {
+        if (!s_popupInstance) {
+            s_popupInstance = this;
+        }
+    }
+
+    dndIsBefore = (el1: any, el2: any) => {
+        if (el2.parentNode === el1.parentNode) {
+            let cur
+            for (cur = el1.previousSibling; cur; cur = cur.previousSibling) {
+                if (cur === el2) return true
+            }
+        }
+        return false;
+    }
+
+    /* find given element target (or parent) which is draggable */
+    dndGetDraggableTarget = (target: any) => {
+        while (target.getAttribute("draggable") !== "true") {
+            if (!target.parentElement) {
+                return undefined;
+            }
+            target = target.parentElement;
+        }
+        return target;
+    }
+
+    dndOver = (e: React.DragEvent<HTMLDivElement>) => {
+        e.preventDefault();
+        const draggableTarget = this.dndGetDraggableTarget(e.target);
+        if (!draggableTarget || !draggableTarget.parentNode) {
+            return;
+        }
+
+        if (this.dndIsBefore(this.state.dndSelected, draggableTarget)) {
+            draggableTarget.parentNode.insertBefore(this.state.dndSelected, draggableTarget)
+        } else {
+            draggableTarget.parentNode.insertBefore(this.state.dndSelected, draggableTarget.nextSibling)
+        }
+    }
+
+    dndDrop = (e: React.DragEvent<HTMLDivElement>) => {
+        this.setState({ dndSelected: undefined });
+        const target = this.dndGetDraggableTarget(e.target);
+        if (!target?.parentNode?.children) {
+            return;
+        }
+        let newItems: MenuItemProps[] = [];
+        Array.from(target.parentNode.children).forEach((child: any) => {
+            const newItem = this.state.items.find((item: MenuItemProps) => item.id === child.getAttribute("id"));
+            newItem && newItems.push(newItem);
+        })
+        if (this.state.setItems) {
+            const setItems: ((items: MenuItemProps[]) => void) = this.state.setItems;
+            setItems(newItems);
+        }
+    }
+
+    dndStart = (e: any) => {
+        const draggableTarget = this.dndGetDraggableTarget(e.target);
+        if (!draggableTarget) {
+            return;
+        }
+
+        e.dataTransfer.effectAllowed = 'move'
+        e.dataTransfer.setData('text', draggableTarget.getAttribute("id"))
+        this.setState({ dndSelected: e.target });
+    }
+
+    static showMenu(menu: MenuProps, anchor: Element): void {
+        s_popupInstance?.setState({
+            "data-testid": undefined,
+            align: undefined,
+            popupId: undefined,
+            draggable: undefined,
+            children: undefined,
+            setItems: undefined,
+            className: undefined,
+            ...menu,
+            anchor
+        });
+    }
+
+    static updateMenu(menu: MenuProps): void {
+        if (s_popupInstance) {
+            if (s_popupInstance.state.popupId === menu.popupId) {
+                s_popupInstance.setState(menu);
+            }
+        }
+    }
+
+    render() {
+        if (!this.state.anchor) {
+            return null;
+        }
+
+        const anchor: Element = this.state.anchor;
+        const rect = anchor.getBoundingClientRect();
+        const x = this.state.align === "right" ? rect?.right : rect?.left;
+        return <div
+            data-testid="menu-toggle"
+            style={{
+                justifyContent: this.state.align === "left" ? "start" : "end",
+                position: "fixed",
+                right: 0,
+                left: 0,
+                top: 0,
+                bottom: 0,
+                backgroundColor: "transparent",
+                zIndex: 101
+            }}
+            className="NuoMenuToggle"
+            onClick={() => this.setState({ anchor: null })}>
+            <div style={{ position: "fixed", right: x, left: x, top: rect?.bottom, bottom: rect?.bottom, zIndex: 102 }}>
+                <div id="NuoMenuPopup" className={"NuoMenuPopup " + (this.state.align === "right" ? " NuoAlignRight" : " NuoAlignLeft")}>
+                    {this.state.items.map((item: MenuItemProps) => <div style={{ zIndex: 102 }}
+                        id={item.id}
+                        data-testid={item["data-testid"]}
+                        draggable={this.state.draggable}
+                        onDrop={this.dndDrop}
+                        onDragOver={this.dndOver}
+                        onDragStart={this.dndStart}
+                        key={item.id}
+                        className="NuoMenuPopupItem"
+                        onClick={(e) => {
+                            e.stopPropagation();
+                            if (item.onClick) {
+                                this.setState({ anchor: null });
+                                item.onClick();
+
+                            }
+                        }}>
+                        {item.label}
+                        {this.state.draggable === true && <DragHandleIcon />}
+                    </div>)}
+                </div></div>
+        </div>;
     }
 }

--- a/ui/src/components/controls/Table.tsx
+++ b/ui/src/components/controls/Table.tsx
@@ -1,6 +1,3 @@
-import { Card, Table as MuiTable, TableHead as MuiTableHead, TableRow as MuiTableRow, TableCell as MuiTableCell, TableBody as MuiTableBody } from '@mui/material';
-import TableContainer from '@mui/material/TableContainer';
-import { isMaterial } from '../../utils/Customizations';
 import { ReactNode } from "react";
 
 type TableProps = {
@@ -11,62 +8,30 @@ type TableProps = {
 
 type ChildProps = {
     children?: ReactNode,
+    className?: string,
     "data-testid"?: string,
 }
 
 export function Table(props: TableProps): JSX.Element {
-    if (isMaterial()) {
-        return <TableContainer data-testid={props["data-testid"]} component={Card}>
-            <MuiTable>
-                {props.children}
-            </MuiTable>
-        </TableContainer>
-    }
-    else {
-        return <table data-testid={props["data-testid"]}>{props.children}</table>
-    }
+    return <div className="NuoTableContainer"><table data-testid={props["data-testid"]} className="NuoTableTable">{props.children}</table></div>
 }
 
 export function TableHead(props: ChildProps): JSX.Element {
-    if (isMaterial()) {
-        return <MuiTableHead>
-            {props.children}
-        </MuiTableHead>
-    }
-    else {
-        return <thead>{props.children}</thead>
-    }
+    return <thead className="NuoTableThead">{props.children}</thead>
 }
 
 export function TableRow(props: ChildProps): JSX.Element {
-    if (isMaterial()) {
-        return <MuiTableRow>
-            {props.children}
-        </MuiTableRow>
-    }
-    else {
-        return <tr>{props.children}</tr>
-    }
+    return <tr className="NuoTableTr">{props.children}</tr>
 }
 
 export function TableCell(props: ChildProps): JSX.Element {
-    if (isMaterial()) {
-        return <MuiTableCell data-testid={props["data-testid"]}>
-            {props.children}
-        </MuiTableCell>
-    }
-    else {
-        return <td data-testid={props["data-testid"]}>{props.children}</td>
-    }
+    return <td data-testid={props["data-testid"]} className={["NuoTableTd", props.className].join(" ")}>{props.children}</td>
+}
+
+export function TableTh(props: ChildProps): JSX.Element {
+    return <th data-testid={props["data-testid"]} className={["NuoTableTh", props.className].join(" ")}>{props.children}</th>
 }
 
 export function TableBody(props: ChildProps): JSX.Element {
-    if (isMaterial()) {
-        return <MuiTableBody>
-            {props.children}
-        </MuiTableBody>
-    }
-    else {
-        return <tbody>{props.children}</tbody>
-    }
+    return <tbody className="NuoTableTbody">{props.children}</tbody>
 }

--- a/ui/src/components/pages/parts/Banner.tsx
+++ b/ui/src/components/pages/parts/Banner.tsx
@@ -45,6 +45,7 @@ function ResponsiveAppBar(resources: string[], t: any) {
 
           <Box sx={{ flexGrow: 1, display: { xs: 'flex', md: 'none' } }}>
             <Menu
+              align="left"
               items={resources.map((resource: string, index: number) => {
                 return {
                   "data-testid": "menu-label-" + resource,

--- a/ui/src/components/pages/parts/Table.tsx
+++ b/ui/src/components/pages/parts/Table.tsx
@@ -2,7 +2,7 @@
 
 import { useNavigate } from 'react-router-dom';
 import { withTranslation } from "react-i18next";
-import { TableBody, TableCell, Table as TableCustom, TableHead, TableRow } from '../../controls/Table';
+import { TableBody, TableTh, TableCell, Table as TableCustom, TableHead, TableRow } from '../../controls/Table';
 import { getResourceByPath, getCreatePath, getChild, replaceVariables } from "../../../utils/schema";
 import FieldFactory from "../../fields/FieldFactory";
 import RestSpinner from "./RestSpinner";
@@ -211,8 +211,8 @@ function Table(props: TempAny) {
             })
         }
 
-        return <TableCell key={row["$ref"]}>
-            <Menu popup={true} items={buttons} align="right" />
+        return <TableCell key={row["$ref"]} className="NuoTableMenuCell">
+            <Menu popupId={"row_menu_" + row["$ref"]} items={buttons} align="right" />
         </TableCell>;
 
     }
@@ -259,12 +259,12 @@ function Table(props: TempAny) {
         <TableCustom data-testid={props["data-testid"]}>
             <TableHead>
                 <TableRow>
-                    {visibleColumns.map((column, index) => <TableCell key={column.id} data-testid={column.id}>
+                    {visibleColumns.map((column, index) => <TableTh key={column.id} data-testid={column.id}>
                         {tableLabels[column.id]}
-                    </TableCell>)}
-                    <TableCell key="$ref" data-testid="$ref">
+                    </TableTh>)}
+                    <TableTh key="$ref" data-testid="$ref" className="NuoTableMenuCell">
                         {data.length > 0 && <TableSettingsColumns data={data} path={path} columns={columns} setColumns={setColumns} />}
-                    </TableCell>
+                    </TableTh>
                 </TableRow>
             </TableHead>
             <TableBody>
@@ -274,7 +274,7 @@ function Table(props: TempAny) {
                         {renderMenuCell(row)}
                     </TableRow>
                 ))}
-                {data.length === 0 && <div data-testid="table_nodata" className="NuoTableNoData">{t("text.noData")}</div>}
+                {data.length === 0 && <tr><td><div data-testid="table_nodata" className="NuoTableNoData">{t("text.noData")}</div></td></tr>}
             </TableBody>
         </TableCustom>
     );

--- a/ui/src/components/pages/parts/TableSettingsColumns.tsx
+++ b/ui/src/components/pages/parts/TableSettingsColumns.tsx
@@ -60,14 +60,13 @@ function TableSettingsColumns(props: TempAny) {
         return {
             id: column.id,
             selected: column.selected,
-            label: <div key={column.id} style={{ display: "flex", flexDirection: "row" }
-            }>
+            label: <div key={column.id} className="NuoTableSettingsItem">
                 <input type="checkbox" id={column.id} checked={column.selected} onChange={() => handleSelection(index)} />
                 <label htmlFor={column.id} onClick={() => handleSelection(index)}>{t("field.label." + column.id, column.id)}</label>
             </div >
         }
     });
-    return <Menu popup={true} draggable={true} items={items} setItems={(items) => {
+    return <Menu popupId={"tableColumnsMenu"} draggable={true} items={items} setItems={(items) => {
         saveColumns(items, path);
         setColumns(items);
     }} align="right" />;

--- a/ui/src/utils/types.ts
+++ b/ui/src/utils/types.ts
@@ -46,7 +46,7 @@ export type MenuItemProps = {
 export type MenuProps = {
     "data-testid"?: string,
     align?: "left" | "right",
-    popup?: boolean,
+    popupId?: string,
     draggable?: boolean,
     children?: ReactNode,
     items: MenuItemProps[],


### PR DESCRIPTION
- popup menu icon now stays on the right of the viewport (even if table is too wide and can be scrolled to the right)
- text under popup icon is faded to white
- I had to move the popup menu to the root of the document (having it as a child of a sticky element caused a lot of layer issuers)
- added drag icons to draggable popup menu's (i.e. for view column sorting)
- extended popup menu labels to full with to allow changing columns by clicking anywhere on the row (not just the label)
- eliminated Material UI from the "Table" view and added same stylesheets. MUI was causing issues with sticky columns.