### PR TITLE
save built WebUI static files into gh-pages repo

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,6 +4,7 @@ on:
     branches:
       - "main"
       - "rel/*"
+      - "agr22/DBAAS-520"
 jobs:
   publish_docker_image:
     name: Publish Docker Image

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,7 +4,6 @@ on:
     branches:
       - "main"
       - "rel/*"
-      - "agr22/DBAAS-520"
 jobs:
   publish_docker_image_and_helm:
     name: Publish Docker Image and helm charts

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,6 +12,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Install JDK 17
         uses: actions/setup-java@v4
         with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -6,8 +6,8 @@ on:
       - "rel/*"
       - "agr22/DBAAS-520"
 jobs:
-  publish_docker_image:
-    name: Publish Docker Image
+  publish_docker_image_and_helm:
+    name: Publish Docker Image and helm charts
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -46,15 +46,6 @@ jobs:
           name: test-results
           path: selenium-tests/target/test-results
           retention-days: 7
-
-  publish_helm_chart:
-    name: Publish Helm Chart
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
       - name: Configure Git
         run: |
           git config user.name "$GITHUB_ACTOR"

--- a/build_utils.sh
+++ b/build_utils.sh
@@ -111,6 +111,11 @@ if [ "$1" == "createHelmPackage" ] ; then
     (cd build/charts && helm package ${REPOSITORY})
     cat ${CHART_FILE} | sed "s/^version: .*/version: \"${VERSION}-latest\"/g" > build/${CHART_FILE}
     (cd build/charts && helm package ${REPOSITORY})
+
+    echo "Create tgz file from static files"
+    mkdir -p build/static_files
+    docker run nuodbaas-webui tgz_static > build/static_files/${REPOSITORY}-html-${SNAPSHOT}.tgz
+    cp build/static_files/${REPOSITORY}-html-${SNAPSHOT}.tgz build/static_files/${REPOSITORY}-html-${VERSION}-latest.tgz
     exit 0
 fi
 
@@ -142,6 +147,7 @@ if [ "$1" == "uploadHelmPackage" ] ; then
         # Update index with new Helm charts
         mv build/charts/*.tgz ./
         helm repo index .
+        mv static_files/*.tgz ./
 
         git add index.yaml *.tgz
         git commit -m "Add chart ${NEW_CHART} to index"

--- a/build_utils.sh
+++ b/build_utils.sh
@@ -99,7 +99,7 @@ if [ "$1" == "createHelmPackage" ] ; then
             echo "This is the first build with a non-existing helm chart. Publishing chart..."
             SNAPSHOT="${VERSION}"
         fi
-    elif [ "${BRANCH}" == "main" ] ; then
+    elif [ "${BRANCH}" == "main" ] || [ "${BRANCH}" == "agr22/DBAAS-520" ]; then
         SNAPSHOT="${VERSION}-${HELM_HASH}+${GIT_HASH}"
     else
         echo "Personal branch ${BRANCH} - not publishing chart"

--- a/build_utils.sh
+++ b/build_utils.sh
@@ -99,7 +99,7 @@ if [ "$1" == "createHelmPackage" ] ; then
             echo "This is the first build with a non-existing helm chart. Publishing chart..."
             SNAPSHOT="${VERSION}"
         fi
-    elif [ "${BRANCH}" == "main" ] || [ "${BRANCH}" == "agr22/DBAAS-520" ]; then
+    elif [ "${BRANCH}" == "main" ] ; then
         SNAPSHOT="${VERSION}-${HELM_HASH}+${GIT_HASH}"
     else
         echo "Personal branch ${BRANCH} - not publishing chart"

--- a/docker/production/files/entrypoint.sh
+++ b/docker/production/files/entrypoint.sh
@@ -1,6 +1,13 @@
 #!/bin/sh
 # (C) Copyright 2024 Dassault Systemes SE.  All Rights Reserved.
 
+if [ "$1" == "tgz_static" ] ; then
+    echo "Exctract static files from image"
+    cd /usr/share/nginx/html
+    tar -czf - -C /usr/share/nginx/html *
+    exit $?
+fi
+
 if [ "${NUODB_CP_REST_URL}" != "" ] ; then
     find /usr/share/nginx/html -type f | while read line; do
         sed -i "s#___NUODB_CP_REST_URL___#${NUODB_CP_REST_URL}#g" ${line}


### PR DESCRIPTION
stores generated static files for the WebUI in the `gh-pages` branch for download using both the git sha as well as "latest" tag (appended after the version number). This complements the existing helm chart in the same branch.