### PR TITLE
add help descriptions to forms and fields

### DIFF
--- a/ui/public/theme/base.css
+++ b/ui/public/theme/base.css
@@ -333,3 +333,57 @@ code {
     background-color: #e0e033;
     padding: 5px 24px;
 }
+.NuoFormHeader {
+    margin-block-start: 0.67em;
+    margin-block-end: 2em;
+    margin-inline-start: 0;
+    margin-inline-end: 0;
+}
+
+.NuoFormHeader>h1 {
+    display: flex;
+    margin-block-start: 0;
+    margin-block-end: 0;
+    font-size: 2em;
+    font-weight: bold;
+    unicode-bidi: isolate;
+}
+
+.NuoFormHeader>label {
+    margin-block-end: 0.67em;
+}
+
+.NuoInfoPopup {
+    display: flex;
+    cursor: default;
+    flex-direction: row;
+    align-items: top;
+    justify-content: right;
+}
+
+.NuoInfoPopup>label {
+    display: none;
+}
+
+.NuoInfoPopup>svg {
+    opacity: 0.5;
+}
+
+.NuoInfoPopup:hover>label {
+    display: flex;
+    text-wrap: wrap;
+    max-width: 500px;
+    background-color: white;
+    box-shadow: 0px 5px 5px -3px rgba(0, 0, 0, 0.2), 0px 8px 10px 1px rgba(0, 0, 0, 0.14), 0px 3px 14px 2px rgba(0, 0, 0, 0.12);
+    position: absolute;
+    margin-top: 30px;
+    margin-left: -1000px;
+    padding: 5px;
+    z-index: 1001;
+}
+
+.NuoArrayLabel {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+}

--- a/ui/public/theme/plain.css
+++ b/ui/public/theme/plain.css
@@ -3,6 +3,8 @@
 }
 .NuoFieldString,
 .NuoFieldSelect {
+    display: flex;
+        flex-direction: row;
     position: relative;
     border: 1px solid;
     margin: 5px;

--- a/ui/src/components/controls/InfoPopup.tsx
+++ b/ui/src/components/controls/InfoPopup.tsx
@@ -1,0 +1,14 @@
+// (C) Copyright 2025 Dassault Systemes SE.  All Rights Reserved.
+
+import InfoIconOutlined from '@mui/icons-material/InfoOutlined';
+
+type InfoPopupProps = {
+    description?: string;
+};
+
+/* Shows an (i) icon which will popup the specified description when hovering over. */
+export default function InfoPopup(props: InfoPopupProps): JSX.Element {
+    const { description } = props;
+
+    return (description && <div className="NuoInfoPopup"><label>{description}</label><InfoIconOutlined /></div>) || <></>;
+}

--- a/ui/src/components/controls/Select.tsx
+++ b/ui/src/components/controls/Select.tsx
@@ -2,12 +2,14 @@
 
 import { ReactNode } from 'react';
 import { isMaterial } from '../../utils/Customizations';
-import { FormControl, InputLabel, MenuItem, Select as MuiSelect } from '@mui/material'
+import { FormControl, InputAdornment, InputLabel, MenuItem, Select as MuiSelect } from '@mui/material'
+import InfoPopup from './InfoPopup';
 
 export type SelectProps = {
     "data-testid"?: string,
     id: string,
     label?: string,
+    description?: string,
     value: string,
     children: ReactNode,
     required?: boolean,
@@ -23,11 +25,22 @@ export type SelectOptionProps = {
 }
 
 export default function Select(props: SelectProps): JSX.Element {
-    const { id, label, required, children } = props;
+    const { id, label, description, required, children } = props;
     if (isMaterial()) {
         return <FormControl key={id} fullWidth>
             <InputLabel id={"label_" + id}>{label}</InputLabel>
-            <MuiSelect labelId={"label_" + id} name={id} label={label} {...props} value={props.value || ""}>
+            <MuiSelect labelId={"label_" + id} name={id} label={label} {...props} value={props.value || ""}
+                endAdornment={(description) &&
+                    <InputAdornment position="end">
+                        {description && <InfoPopup description={description} />}
+                    </InputAdornment>
+                }
+                sx={{
+                    "& .MuiSelect-icon": {
+                        right: description ? "40px !important;" : "0"
+                    },
+                }}
+            >
                 {children}
             </MuiSelect>
             {required && <span>Required</span>}
@@ -40,6 +53,7 @@ export default function Select(props: SelectProps): JSX.Element {
                 {children}
             </select>
             {required && <span>Required</span>}
+            {description && <InfoPopup description={description} />}
         </div>;
     }
 }

--- a/ui/src/components/controls/TextField.tsx
+++ b/ui/src/components/controls/TextField.tsx
@@ -1,8 +1,9 @@
-// (C) Copyright 2024 Dassault Systemes SE.  All Rights Reserved.
+// (C) Copyright 2025 Dassault Systemes SE.  All Rights Reserved.
 
 import React from 'react';
 import { isMaterial } from '../../utils/Customizations';
-import { IconButton, InputAdornment, TextField as MuiTextField } from '@mui/material'
+import { IconButton, InputAdornment, TextField as MuiTextField } from '@mui/material';
+import InfoPopup from './InfoPopup';
 
 export type TextFieldProps = {
     "data-testid"?: string,
@@ -10,6 +11,7 @@ export type TextFieldProps = {
     required?: boolean,
     id: string,
     label: string,
+    description?: string,
     type?: "password" | "datetime-local" | "text",
     value?: string,
     defaultValue?: string,
@@ -31,18 +33,20 @@ export default function TextField(props: TextFieldProps): JSX.Element {
             fullWidth={true}
             {...fieldProps}
             name={props.id}
+            aria-details={props.description}
             error={!!props.error}
             helperText={props.error}
-            slotProps={(props.icon && {
+            slotProps={((props.icon || fieldProps.description) && {
                 input: {
                     endAdornment:
                         <InputAdornment position="end">
-                            <IconButton
+                            {props.icon && <IconButton
                                 aria-label=""
                                 onClick={props.iconOnClick}
                             >
                                 {props.icon}
-                            </IconButton>
+                            </IconButton>}
+                            {props.description && <InfoPopup description={props.description} />}
                         </InputAdornment>
                 }
             }) || undefined
@@ -51,13 +55,14 @@ export default function TextField(props: TextFieldProps): JSX.Element {
     }
     else {
         return <div>
-            <div className="NuoFieldBase NuoFieldString" key={props.id}>
+            <div className="NuoFieldBase NuoFieldString" key={props.id} aria-details={props.description}>
                 <label>{props.label}</label>
                 <input name={props.id} {...fieldProps} />
-                <button onClick={(event) => {
+                {props.iconOnClick && <button onClick={(event) => {
                     event.preventDefault();
                     props.iconOnClick && props.iconOnClick(event);
-                }}>{props.icon}</button>
+                }}>{props.icon}</button>}
+                {props.description && <InfoPopup description={props.description} />}
             </div>
             {props.error !== "" && <div className="NuoFieldError">{props.error}</div>}
         </div>

--- a/ui/src/components/fields/FieldArray.tsx
+++ b/ui/src/components/fields/FieldArray.tsx
@@ -6,6 +6,7 @@ import { Table, TableBody, TableCell, TableHead, TableRow } from "../controls/Ta
 import FieldBase, { FieldBaseType, FieldProps } from './FieldBase'
 import FieldFactory from "./FieldFactory"
 import FieldMessage from "./FieldMessage";
+import InfoPopup from "../controls/InfoPopup";
 
 export default function FieldArray(props: FieldProps): FieldBaseType {
     /**
@@ -61,7 +62,10 @@ export default function FieldArray(props: FieldProps): FieldBaseType {
         return <Table key={prefix}>
             <TableHead>
                 <TableRow>
-                    <TableCell>{t("field.label." + prefix, prefix)}</TableCell>
+                    <TableCell className="NuoArrayLabel">
+                        {t("field.label." + prefix, prefix)}
+                        <InfoPopup description={parameter.description} />
+                    </TableCell>
                 </TableRow>
             </TableHead>
             <TableBody>

--- a/ui/src/components/fields/FieldBoolean.tsx
+++ b/ui/src/components/fields/FieldBoolean.tsx
@@ -11,9 +11,9 @@ export default function FieldBoolean(props: FieldProps): FieldBaseType {
      * show Field of type Boolean using the values and schema definition
      */
     function show(): ReactNode {
-        const { prefix, label, values, required, setValues, autoFocus, readonly, t } = props;
+        const { prefix, label, values, required, setValues, autoFocus, readonly, parameter, t } = props;
         let value = getValue(values, prefix);
-        return <Select id={prefix} key={prefix} label={label} value={String(value || false)} autoFocus={autoFocus} required={required} onChange={({ target: input }) => {
+        return <Select id={prefix} key={prefix} label={label} description={parameter.description} value={String(value || false)} autoFocus={autoFocus} required={required} onChange={({ target: input }) => {
                 let v = { ...values };
             setValue(v, prefix, input.value);
                 setValues(v);

--- a/ui/src/components/fields/FieldCrontab.tsx
+++ b/ui/src/components/fields/FieldCrontab.tsx
@@ -13,7 +13,7 @@ export default function FieldCrontab(props: FieldProps): FieldBaseType {
      * show Field of type Boolean using the values and schema definition
      */
     function show(): ReactNode {
-        const { prefix, label, values, setValues, errors, autoFocus, readonly, required, t } = props;
+        const { prefix, label, parameter, values, setValues, errors, autoFocus, readonly, required, t } = props;
         let error = (errors && (prefix in errors) && errors[prefix]) || "";
         let value = getValue(values, prefix) || "";
         const parts = value.split(" ");
@@ -40,7 +40,7 @@ export default function FieldCrontab(props: FieldProps): FieldBaseType {
 
         return <div key={prefix} className={(isOther && "NuoFieldCrontab") || ""}>
             <label id={"label_" + prefix}>{isOther && label}</label>
-            <Select id={prefix} key={prefix} label={(!isOther && label) || ""} value={frequency} required={required} autoFocus={autoFocus} onChange={(e: any) => {
+            <Select id={prefix} key={prefix} label={(!isOther && label) || ""} description={parameter.description} value={frequency} required={required} autoFocus={autoFocus} onChange={(e: any) => {
                 let v = { ...values };
                 if (e.target.value === "other") {
                     setValue(v, prefix, "* * * * *");
@@ -81,7 +81,7 @@ export default function FieldCrontab(props: FieldProps): FieldBaseType {
     function getDisplayValue(): ReactNode {
         const { prefix, values, t } = props;
         const value = getValue(values, prefix);
-        return t("field.enum." + prefix + "." + value, prefix + "." + value);
+        return t("field.enum." + prefix + "." + value, value);
     }
 
     /** validate field and set error state

--- a/ui/src/components/fields/FieldDateTime.tsx
+++ b/ui/src/components/fields/FieldDateTime.tsx
@@ -172,7 +172,7 @@ export default function FieldDateTime(props: FieldProps): FieldBaseType {
      * @returns
      */
     function show(): ReactNode {
-        const { prefix, label, values, errors, required, setValues, autoFocus, updateErrors, readonly, t } = props;
+        const { prefix, label, values, errors, required, setValues, autoFocus, updateErrors, readonly, parameter, t } = props;
         let value = getValue(values, prefix);
         let editValue = getValue(values, "_" + prefix);
         if (editValue === null) {
@@ -184,6 +184,7 @@ export default function FieldDateTime(props: FieldProps): FieldBaseType {
             required={required}
             id={prefix}
             label={label}
+            description={parameter.description}
             value={editValue}
             autoFocus={autoFocus}
             error={error}

--- a/ui/src/components/fields/FieldInteger.tsx
+++ b/ui/src/components/fields/FieldInteger.tsx
@@ -12,10 +12,10 @@ export default function FieldInteger(props: FieldProps): FieldBaseType {
      * @returns
      */
     function show(): ReactNode {
-        const { prefix, label, values, required, setValues, autoFocus, readonly } = props;
+        const { prefix, label, values, required, setValues, autoFocus, readonly, parameter } = props;
         let value = String(getValue(values, prefix) || "");
 
-        return <TextField key={prefix} required={required} id={prefix} label={label} value={value} autoFocus={autoFocus} onChange={({ currentTarget: input }) => {
+        return <TextField key={prefix} required={required} id={prefix} label={label} description={parameter.description} value={value} autoFocus={autoFocus} onChange={({ currentTarget: input }) => {
             let v = { ...values };
             setValue(values, prefix, input.value);
             setValues(v);

--- a/ui/src/components/fields/FieldMap.tsx
+++ b/ui/src/components/fields/FieldMap.tsx
@@ -7,6 +7,7 @@ import FieldBase, { FieldBaseType, FieldProps } from "./FieldBase"
 import { TempAny } from "../../utils/types";
 import { ReactNode } from "react";
 import { Table, TableBody, TableCell, TableHead, TableRow } from "../controls/Table";
+import InfoPopup from "../controls/InfoPopup";
 
 export default function FieldMap(props: FieldProps): FieldBaseType {
 
@@ -53,7 +54,7 @@ export default function FieldMap(props: FieldProps): FieldBaseType {
      * @returns
      */
     function show(): ReactNode {
-        const { prefix, values, errors, setValues, readonly, t } = props;
+        const { prefix, values, errors, setValues, readonly, parameter, t } = props;
 
         let valueKeys = Object.keys(getValue(values, prefix) || {});
         let rows = [];
@@ -142,9 +143,9 @@ export default function FieldMap(props: FieldProps): FieldBaseType {
             <Table key={prefix}>
                 <TableHead>
                     <TableRow>
-                        <TableCell>{t("field.map.header.label.key")}</TableCell>
-                        <TableCell>{t("field.map.header.label.value")}</TableCell>
-                        <TableCell></TableCell>
+                        <TableCell>{t("field.label." + prefix, prefix)} {t("field.map.header.label.key")}</TableCell>
+                        <TableCell>{t("field.label." + prefix, prefix)} {t("field.map.header.label.value")}</TableCell>
+                        <TableCell className="NuoTableMenuCell"><InfoPopup description={parameter.description} /></TableCell>
                     </TableRow>
                 </TableHead>
                 <TableBody>

--- a/ui/src/components/fields/FieldPassword.tsx
+++ b/ui/src/components/fields/FieldPassword.tsx
@@ -12,10 +12,10 @@ export default function FieldPassword(props: FieldProps): FieldBaseType {
      * @returns
      */
     function show(): ReactNode {
-        let { prefix, label, values, errors, required, setValues, autoFocus, readonly } = props;
+        let { prefix, label, values, errors, required, setValues, autoFocus, readonly, parameter } = props;
         let value = String(getValue(values, prefix) || "");
         let error = (errors && (prefix in errors) && errors[prefix]) || "";
-        return <TextField key={prefix} type="password" required={required} id={prefix} label={label} value={value} autoFocus={autoFocus} onChange={({ currentTarget: input }) => {
+        return <TextField key={prefix} type="password" required={required} id={prefix} label={label} description={parameter.description} value={value} autoFocus={autoFocus} onChange={({ currentTarget: input }) => {
             let v = { ...values };
             setValue(v, prefix, input.value);
             setValues(v);

--- a/ui/src/components/fields/FieldSelect.tsx
+++ b/ui/src/components/fields/FieldSelect.tsx
@@ -14,7 +14,7 @@ export default function FieldSelect(props: FieldProps): FieldBaseType {
         const { prefix, label, values, parameter, required, setValues, autoFocus, readonly, t } = props;
         let value = getValue(values, prefix);
 
-        return <Select id={prefix} key={prefix} label={label} value={value} autoFocus={autoFocus} required={required} onChange={(e: any) => {
+        return <Select id={prefix} key={prefix} label={label} description={parameter.description} value={value} autoFocus={autoFocus} required={required} onChange={(e: any) => {
             let v = { ...values };
             setValue(v, prefix, e.target.value);
             setValues(v);

--- a/ui/src/components/fields/FieldString.tsx
+++ b/ui/src/components/fields/FieldString.tsx
@@ -11,10 +11,10 @@ export default function FieldString(props: FieldProps): FieldBaseType {
      * @returns
      */
     function show(): ReactNode {
-        const { prefix, label, values, errors, required, setValues, autoFocus, readonly } = props;
+        const { prefix, label, values, errors, required, setValues, autoFocus, readonly, parameter } = props;
         let value = String(getValue(values, prefix) || "");
         let error = (errors && (prefix in errors) && errors[prefix]) || "";
-        return <TextField key={prefix} required={required} id={prefix} label={label} value={value} autoFocus={autoFocus} onChange={({ currentTarget: input }) => {
+        return <TextField key={prefix} required={required} id={prefix} label={label} description={parameter.description} value={value} autoFocus={autoFocus} onChange={({ currentTarget: input }) => {
             let v = { ...values };
             setValue(v, prefix, input.value);
             setValues(v);

--- a/ui/src/components/pages/parts/CreateEditEntry.tsx
+++ b/ui/src/components/pages/parts/CreateEditEntry.tsx
@@ -14,12 +14,17 @@ import { FieldValuesType, FieldParameterType, TempAny, StringMapType, FieldParam
 import { getCustomizations } from "../../../utils/Customizations";
 import { withTranslation } from "react-i18next";
 
+type PutResourceType = {
+    summary?: string;
+}
+
 /**
  * common implementation of the /resource/create/* and /resource/edit/* requests
  */
 function CreateEditEntry({ schema, path, data, readonly, t }: TempAny) {
     const navigate = useNavigate();
 
+    const [putResource, setPutResource] = useState<PutResourceType>({});
     const [formParameters, setFormParameters] = useState<FieldParametersType>({});
     const [sectionFormParameters, setSectionFormParameters] = useState([]);
     const [urlParameters, setUrlParameters] = useState<FieldParametersType>({});
@@ -236,6 +241,7 @@ function CreateEditEntry({ schema, path, data, readonly, t }: TempAny) {
         setValues(v);
         setFocus(v, formParams);
         setFormParameters(formParams);
+        setPutResource(putResource);
         setSectionFormParameters(sectionFormParams);
     }, [schema, path, data, t]);
 
@@ -296,7 +302,10 @@ function CreateEditEntry({ schema, path, data, readonly, t }: TempAny) {
     return <div className="NuoContainerSM">
         <RestSpinner />
         <form>
+            <div className="NuoFormHeader">
             {!readonly && <h1>{data ? t("text.editEntryForPath", { path }) : t("text.createEntryForPath", { path })}</h1>}
+                <label>{putResource.summary}</label>
+            </div>
             <div className="fields">
                 {urlParameters && Object.keys(urlParameters)
                     .filter(key => urlParameters[key].in === "query")

--- a/ui/src/utils/types.ts
+++ b/ui/src/utils/types.ts
@@ -23,6 +23,7 @@ export type FieldParameterType = {
     properties?: FieldParametersType,
     additionalProperties?: FieldParameterType
     enum?: string[],
+    description?: string,
     schema?: {
         default: boolean|string,
         type: string


### PR DESCRIPTION
there is a new `(i)` icon in each field which provides field descriptions when hovering over. Also it adds a form description just below the form title. To avoid two tabs to advance to the next field, the `(i)` icon is not accessible via the keyboard, however an aria-details is provided for those using a screen reader.