### PR TITLE
Form Layout improvements

### DIFF
--- a/selenium-tests/src/test/java/com/nuodb/selenium/SeleniumTestHelper.java
+++ b/selenium-tests/src/test/java/com/nuodb/selenium/SeleniumTestHelper.java
@@ -233,7 +233,7 @@ public class SeleniumTestHelper {
         click("login_button");
         retryStale(()->{
             String text = waitText("path_component");
-            assertEquals("Management\n>\nHome", text);
+            assertEquals("Home\n>\nHome", text);
         });
         waitElement("banner-done");
     }

--- a/selenium-tests/src/test/java/com/nuodb/selenium/TestRoutines.java
+++ b/selenium-tests/src/test/java/com/nuodb/selenium/TestRoutines.java
@@ -147,6 +147,9 @@ public class TestRoutines extends SeleniumTestHelper {
         WebElement createButton = waitElement("list_resource__create_button_" + resource);
         createButton.click();
         for (int i=0; i<fieldValueList.length; i += 2) {
+            if(fieldValueList[i].startsWith("accessRule")) {
+                waitElement("section-title-access-deny-rules").click();
+            }
             WebElement element = waitInputElementByName(fieldValueList[i]);
             if(!element.getAttribute("value").equals(fieldValueList[i+1])) {
                 element.sendKeys(fieldValueList[i+1]);

--- a/selenium-tests/src/test/java/com/nuodb/selenium/basic/DatabaseTest.java
+++ b/selenium-tests/src/test/java/com/nuodb/selenium/basic/DatabaseTest.java
@@ -3,7 +3,6 @@
 package com.nuodb.selenium.basic;
 
 import org.junit.jupiter.api.Test;
-import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 
 import com.nuodb.selenium.Constants;
@@ -16,7 +15,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.net.MalformedURLException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 
 public class DatabaseTest extends TestRoutines {
     @Test

--- a/selenium-tests/src/test/java/com/nuodb/selenium/basic/DatabaseTest.java
+++ b/selenium-tests/src/test/java/com/nuodb/selenium/basic/DatabaseTest.java
@@ -14,7 +14,9 @@ import static com.nuodb.selenium.SeleniumAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.net.MalformedURLException;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 public class DatabaseTest extends TestRoutines {
     @Test
@@ -93,20 +95,27 @@ public class DatabaseTest extends TestRoutines {
        clickMenu("databases");
 
        // perform "Start Database" action
-       menuCells = waitTableElements("list_resource__table", "name", databaseName, MENU_COLUMN);
-       assertEquals(1, menuCells.size());
-       clickPopupMenu(menuCells.get(0), "confirm.start.database.title");
-       waitElement("dialog_button_yes").click();
-       waitRestComplete();
+       ArrayList<List<WebElement>> menuCells1 = new ArrayList<>();
+       retry(()->{
+            menuCells1.clear();
+            menuCells1.add(waitTableElements("list_resource__table", "name", databaseName, MENU_COLUMN));
+            assertEquals(1, menuCells1.get(0).size());
+            clickPopupMenu(menuCells1.get(0).get(0), "confirm.start.database.title");
+        });
+         waitElement("dialog_button_yes").click();
+         waitRestComplete();
 
        // TODO(agr22) - workaround to refresh view - we're still running on Control Plane 2.6 for this integration test
        clickMenu("projects");
        clickMenu("databases");
 
        // find database and "Stop Database" button
-       menuCells = waitTableElements("list_resource__table", "name", databaseName, MENU_COLUMN);
-       assertEquals(1, menuCells.size());
-       clickPopupMenu(menuCells.get(0), "confirm.stop.database.title");
+       retry(()->{
+            menuCells1.clear();
+            menuCells1.add(waitTableElements("list_resource__table", "name", databaseName, MENU_COLUMN));
+            assertEquals(1, menuCells1.get(0).size());
+       });
+       clickPopupMenu(menuCells1.get(0).get(0), "confirm.stop.database.title");
        waitElement("dialog_button_no").click();
        waitRestComplete();
 

--- a/selenium-tests/src/test/java/com/nuodb/selenium/basic/DatabaseTest.java
+++ b/selenium-tests/src/test/java/com/nuodb/selenium/basic/DatabaseTest.java
@@ -114,8 +114,8 @@ public class DatabaseTest extends TestRoutines {
             menuCells1.clear();
             menuCells1.add(waitTableElements("list_resource__table", "name", databaseName, MENU_COLUMN));
             assertEquals(1, menuCells1.get(0).size());
-       });
-       clickPopupMenu(menuCells1.get(0).get(0), "confirm.stop.database.title");
+            clickPopupMenu(menuCells1.get(0).get(0), "confirm.stop.database.title");
+        });
        waitElement("dialog_button_no").click();
        waitRestComplete();
 

--- a/selenium-tests/src/test/java/com/nuodb/selenium/basic/UserTest.java
+++ b/selenium-tests/src/test/java/com/nuodb/selenium/basic/UserTest.java
@@ -49,23 +49,23 @@ public class UserTest extends TestRoutines {
         clickMenu("users");
 
         // find user and start edit mode
-        retryStale(()->{
+        retry(()->{
             List<WebElement> buttonsCell = waitTableElements("list_resource__table", "name", userName, MENU_COLUMN);
             assertEquals(1, buttonsCell.size());
             clickPopupMenu(buttonsCell.get(0), "edit_button");
         });
-
-        // edit user and save
-        waitElement("section-title-labels").click();
-        waitInputElementByName("labels.key").sendKeys(userName);
-        waitInputElementByName("labels.value").sendKeys(userName);
-        waitElement("add_button_labels").click();
 
         // verify allowCrossOrganizationAccess / organization / name fields are disabled in edit mode
         String [] disabledFields = new String[]{"allowCrossOrganizationAccess", "organization", "name"};
         for(String field : disabledFields ) {
             assertFalse(waitPresentInputElementByName(field).isEnabled(), "\"" + field + "\" field is not disabled");
         }
+
+        // edit user and save
+        waitElement("section-title-labels").click();
+        waitInputElementByName("labels.key").sendKeys(userName);
+        waitInputElementByName("labels.value").sendKeys(userName);
+        waitElement("add_button_labels").click();
 
         // save user
         waitElement("create_resource__create_button").click();

--- a/ui/public/theme/base.css
+++ b/ui/public/theme/base.css
@@ -797,3 +797,56 @@ button:focus {
     background-color: #4377a2;
     box-shadow: 2px 2px 5px -3px rgba(0, 0, 0, 0.2), 4px 4px 10px 1px rgba(0, 0, 0, 0.14), 1px 1px 14px 2px rgba(0, 0, 0, 0.12);
 }
+.RestSpinner {
+    position: absolute;
+    top: 30%;
+    bottom: 70%;
+    left: 50%;
+    right: 50%;
+}
+
+.NuoTabs>ul {
+    display: flex;
+    flex-direction: row;
+    justify-content: baseline;
+    padding: 0;
+    margin: 20px 20px 0 20px;
+}
+
+.NuoTabs>ul>li {
+    display: flex;
+    flex-direction: column;
+    background-color: #fff;
+    color: rgba(0, 0, 0, 0.87);
+    margin: 0 15px 15px 15px 15px;
+    padding: 10px;
+    border-bottom: 1px solid rgba(0, 0, 0, 0.2);
+    z-index: 0;
+    cursor: default;
+}
+
+.NuoTabsSelected {
+    display: flex;
+    flex-direction: column;
+    box-shadow: 0 0px 10px -1px rgba(0, 0, 0, .2), 0px -1px 1px 0px rgba(0, 0, 0, 0.14), 0px -1px 3px 0px rgba(0, 0, 0, 0.12);
+    background-color: #fff;
+    color: rgba(0, 0, 0, 0.87);
+    border-radius: 10px 10px 0 0;
+    margin: 0 15px 15px 15px 15px;
+    border-bottom: 0 !important;
+    z-index: 1 !important;
+}
+
+.NuoTabsBody {
+    display: flex;
+    flex-direction: column;
+    position: relative;
+    box-shadow: 0 0px 10px 1px rgba(0, 0, 0, .2), 0px 1px 1px 0px rgba(0, 0, 0, 0.14), 0px 1px 3px 0px rgba(0, 0, 0, 0.12);
+    clip-path: inset(0px -10px -10px -10px);
+    background-color: #fff;
+    color: rgba(0, 0, 0, 0.87);
+    border-radius: 0 0 10px 10px;
+    margin: 0 20px 20px 20px;
+    padding: 10px;
+    z-index: 2 !important;
+}

--- a/ui/public/theme/base.css
+++ b/ui/public/theme/base.css
@@ -823,6 +823,7 @@ button:focus {
     border-bottom: 1px solid rgba(0, 0, 0, 0.2);
     z-index: 0;
     cursor: default;
+    text-wrap: nowrap;
 }
 
 .NuoTabsSelected {

--- a/ui/public/theme/base.css
+++ b/ui/public/theme/base.css
@@ -25,6 +25,10 @@ html {
     }
 }
 
+.NuoListResourceHeader {
+    display: flex;
+    flex-direction: column;
+}
 .NuoListResourceHeader>h3 {
     padding: 0 20px;
     font-size: 1.5em;
@@ -809,8 +813,9 @@ button:focus {
     display: flex;
     flex-direction: row;
     justify-content: baseline;
-    padding: 0;
-    margin: 20px 20px 0 20px;
+    padding: 5px 5px 0 5px;
+        margin: 20px 20px 0 15px;
+        overflow: overlay;
 }
 
 .NuoTabs>ul>li {
@@ -850,4 +855,7 @@ button:focus {
     margin: 0 20px 20px 20px;
     padding: 10px;
     z-index: 2 !important;
+}
+.NuoGap {
+    margin: .5em 0;
 }

--- a/ui/public/theme/base.json
+++ b/ui/public/theme/base.json
@@ -94,32 +94,13 @@
         }
     },
     "forms": {
-        "/users?/{organization}": {
+        "/users?/{organization}?/{name}": {
             "sections": [
                 {
                     "fields": {
                         "organization": {},
                         "name": {},
-                        "password": {
-                            "required": true
-                        },
-                        "accessRule": {}
-                    }
-                },
-                {
-                    "title": "section.title.advanced",
-                    "fields": {
-                        "*": {}
-                    }
-                }
-            ]
-        },
-        "/users/{organization}/{name}": {
-            "sections": [
-                {
-                    "fields": {
-                        "organization": {},
-                        "name": {}
+                        "password": {}
                     }
                 },
                 {
@@ -134,12 +115,6 @@
                     "title": "section.title.labels",
                     "fields": {
                         "labels": {}
-                    }
-                },
-                {
-                    "title": "section.title.change.password",
-                    "fields": {
-                        "password": {}
                     }
                 },
                 {

--- a/ui/src/components/controls/Tabs.tsx
+++ b/ui/src/components/controls/Tabs.tsx
@@ -20,7 +20,7 @@ export function Tabs({ children }: TabsProps) {
 
     return <div className="NuoTabs">
         <ul>{children.map((child, index) => (
-            <li
+            <li key={child.props.id} data-testid={child.props.id}
                 className={index === currentTab ? "NuoTabsSelected" : ""}
                 onClick={() => {
                     setCurrentTab(index);

--- a/ui/src/components/controls/Tabs.tsx
+++ b/ui/src/components/controls/Tabs.tsx
@@ -1,3 +1,5 @@
+// (C) Copyright 2024 Dassault Systemes SE.  All Rights Reserved.
+
 import { ReactElement, ReactNode, useState } from "react"
 
 type TabProps = {

--- a/ui/src/components/controls/Tabs.tsx
+++ b/ui/src/components/controls/Tabs.tsx
@@ -1,0 +1,37 @@
+import { ReactElement, ReactNode, useState } from "react"
+
+type TabProps = {
+    id: string;
+    label: string;
+    children: ReactNode;
+}
+
+export function Tab({ children }: TabProps) {
+    return <>{children}</>
+}
+
+type TabsProps = {
+    children: ReactElement[];
+}
+
+export function Tabs({ children }: TabsProps) {
+    children = children.filter(child => child.props.id && child.props.label && child.props.children);
+    const [currentTab, setCurrentTab] = useState<number>(0);
+
+    return <div className="NuoTabs">
+        <ul>{children.map((child, index) => (
+            <li
+                className={index === currentTab ? "NuoTabsSelected" : ""}
+                onClick={() => {
+                    setCurrentTab(index);
+                }}
+            >
+                {child.props.label}
+            </li>))}
+            <li style={{ display: "flex", flex: "1 1 auto" }}></li>
+        </ul>
+        <div className="NuoTabsBody">
+            {children[currentTab]}
+        </div>
+    </div>
+}

--- a/ui/src/components/fields/FieldObject.tsx
+++ b/ui/src/components/fields/FieldObject.tsx
@@ -25,7 +25,7 @@ export default function FieldObject(props: FieldProps): FieldBaseType {
             if (defaultValue !== null) {
                 setValue(values, prefixKey, defaultValue);
             }
-            return <div key={key} className="gap">{(FieldFactory.create({
+            return <div key={key} className="NuoGap">{(FieldFactory.create({
                 ...props,
                 prefix: prefixKey,
                 parameter: properties[key],

--- a/ui/src/components/pages/Home.tsx
+++ b/ui/src/components/pages/Home.tsx
@@ -7,7 +7,7 @@ import { withTranslation } from "react-i18next";
 
 function Home(props: PageProps) {
     return <PageLayout {...props}>
-        <Path schema={props.schema} path="Home" filterValues={[]} />
+        <Path schema={props.schema} prefixLabel={"Home"} path="Home" filterValues={[]} />
     </PageLayout>;
 }
 

--- a/ui/src/components/pages/ListResource.tsx
+++ b/ui/src/components/pages/ListResource.tsx
@@ -1,7 +1,7 @@
 // (C) Copyright 2024-2025 Dassault Systemes SE.  All Rights Reserved.
 
 import { useEffect, useState } from "react";
-import { useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
 import Table from "./parts/Table";
 import { getResourceEvents, getResourceByPath, getFilterField } from "../../utils/schema";
 import { Rest } from "./parts/Rest";
@@ -31,6 +31,8 @@ function ListResource(props: PageProps) {
     const [allItems, setAllItems] = useState([]);
     const [abortController, setAbortController] = useState<TempAny>(null);
     const [search, setSearch] = useState("");
+
+    const navigate = useNavigate();
 
     useEffect(() => {
         if (!schema) {
@@ -123,7 +125,7 @@ function ListResource(props: PageProps) {
         const dataNotDeleted = itemsAndPath.items.filter((d: TempAny) => d.__deleted__ !== true);
         return (
             <PageLayout {...props} >
-                <ResourceHeader schema={schema} path={path} type="list" filterValues={getFilterValues()} />
+                <ResourceHeader schema={schema} path={path} type="list" filterValues={getFilterValues()} onAction={() => navigate("/ui/resource/create" + path)} />
                 <div className="NuoTableContainer">
                     <div className="NuoTableOptions">
                         <Search search={search} setSearch={(search: string) => {

--- a/ui/src/components/pages/OrganizationOverview.tsx
+++ b/ui/src/components/pages/OrganizationOverview.tsx
@@ -7,7 +7,7 @@ import { withTranslation } from "react-i18next";
 
 function OrganizationOverview(props: PageProps) {
     return <PageLayout {...props}>
-        <Path schema={props.schema} path="Organization Overview" filterValues={[]} />
+        <Path schema={props.schema} prefixLabel="Organization" path="Organization Overview" filterValues={[]} />
     </PageLayout>;
 }
 

--- a/ui/src/components/pages/ViewResource.tsx
+++ b/ui/src/components/pages/ViewResource.tsx
@@ -3,7 +3,6 @@
 import { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
 import CreateEditEntry from "./parts/CreateEditEntry";
-import Path from "./parts/Path";
 import { getResourceByPath } from "../../utils/schema";
 import { Rest } from "./parts/Rest";
 import Auth from "../../utils/auth";
@@ -40,7 +39,6 @@ function ViewResource(props: PageProps) {
 
     return (
         <PageLayout {...props}>
-            <Path schema={schema} path={path} />
             <CreateEditEntry schema={schema} path={path} data={data} readonly={true} />
         </PageLayout>
     );

--- a/ui/src/components/pages/parts/CreateEditEntry.tsx
+++ b/ui/src/components/pages/parts/CreateEditEntry.tsx
@@ -322,7 +322,7 @@ function CreateEditEntry({ schema, path, data, readonly, org, t }: TempAny) {
             const ro = readonly
                 || (data && (key in urlParameters || key === "name" || formParameter["x-immutable"] === true))
                 || (key === "organization" && getSchemaPath(schema, path)?.includes("{organization}"));
-            return (FieldFactory.create({
+            return <div className="NuoGap">{(FieldFactory.create({
                 path,
                 prefix: key,
                 label: t("field.label." + key, key),
@@ -337,7 +337,7 @@ function CreateEditEntry({ schema, path, data, readonly, org, t }: TempAny) {
                 required: false,
                 readonly: ro,
                 t
-            })).show();
+            })).show()}</div>
         });
 
         const label = section.title || t("section.title.general");

--- a/ui/src/components/pages/parts/CreateEditEntry.tsx
+++ b/ui/src/components/pages/parts/CreateEditEntry.tsx
@@ -6,13 +6,14 @@ import FieldFactory from "../../fields/FieldFactory";
 import { getResourceByPath, getCreatePath, getChild, arrayToObject, getDefaultValue, submitForm, getSchemaPath } from "../../../utils/schema";
 import { RestSpinner } from "./Rest";
 import Button from "../../controls/Button";
-import Accordion from "../../controls/Accordion";
 import Auth from "../../../utils/auth";
 import { setValue } from "../../fields/utils";
 import { matchesPath } from "../../../utils/schema";
 import { FieldValuesType, FieldParameterType, TempAny, StringMapType, FieldParametersType } from "../../../utils/types";
 import { getCustomizations } from "../../../utils/Customizations";
 import { withTranslation } from "react-i18next";
+import ResourceHeader from "./ResourceHeader";
+import { Tab, Tabs } from "../../controls/Tabs";
 
 type PutResourceType = {
     summary?: string;
@@ -291,19 +292,17 @@ function CreateEditEntry({ schema, path, data, readonly, org, t }: TempAny) {
                 t
             })).show();
         });
-        if (ret && ret.length > 0 && section.title) {
-            ret = <Accordion key={section.id || "section-" + section.title.toLowerCase()} data-testid={section.id || "section-" + section.title.toLowerCase()} summary={section.title}>
-                {ret}
-            </Accordion>;
-        }
-        return ret;
+
+        const label = section.title || t("section.title.general");
+        const id = section.id || "section-" + label.toLowerCase();
+        return <Tab key={id} id={id} label={label}>{ret}</Tab>;
     }
 
-    return <div className="NuoContainerSM">
+    return <>
         <RestSpinner />
+        <ResourceHeader schema={schema} path={path} type="create" />
         <form>
             <div className="NuoFormHeader">
-            {!readonly && <h1>{data ? t("text.editEntryForPath", { path }) : t("text.createEntryForPath", { path })}</h1>}
                 <label>{putResource.summary}</label>
             </div>
             <div className="fields">
@@ -329,9 +328,11 @@ function CreateEditEntry({ schema, path, data, readonly, org, t }: TempAny) {
                         })).show();
                     }
                     )}
-                {sectionFormParameters.map(section => {
-                    return showSectionFields(section);
-                })}
+                <Tabs>
+                    {sectionFormParameters.map(section => {
+                        return showSectionFields(section);
+                    })}
+                </Tabs>
 
                 {("_error" in errors) && <h3 style={{ color: "red" }}>{errors["_error"]}</h3>}
                 {("_errorDetail" in errors) && <div style={{ color: "red" }}>{errors["_errorDetail"]}</div>}
@@ -377,7 +378,7 @@ function CreateEditEntry({ schema, path, data, readonly, org, t }: TempAny) {
                 </React.Fragment>}
             </div>
         </form>
-    </div>
+    </>
 }
 
 export default withTranslation()(CreateEditEntry);

--- a/ui/src/components/pages/parts/Path.tsx
+++ b/ui/src/components/pages/parts/Path.tsx
@@ -14,11 +14,13 @@ import { SchemaType } from "../../../utils/types"
 type PathProps = {
     schema: SchemaType;
     path: string;
+    prefixLabel: string;
+    postfixLabel?: string;
     filterValues?: string[];
     org?: string;
     t: any;
 }
-function Path({ schema, path, filterValues, org, t }: PathProps) {
+function Path({ schema, path, prefixLabel, postfixLabel, filterValues, org, t }: PathProps) {
     const navigate = useNavigate();
 
     const StyledBreadcrumbs = styled(Breadcrumbs)({
@@ -56,29 +58,30 @@ function Path({ schema, path, filterValues, org, t }: PathProps) {
     const schemaPath = getSchemaPath(schema, path) || "";
     return <div style={{ display: "flex", flexDirection: "row", alignItems: "center" }}>
         <StyledBreadcrumbs data-testid="path_component" separator=">" aria-label="resources" style={{ color: "#b5b9bc", fontSize: "1em", padding: "0 20px", display: "flex", flexWrap: "nowrap" }}>
-            <Typography key="management" color="text.primary" style={{ fontSize: "1em" }}>{t("list.label.management")}</Typography>
+            {prefixLabel && <Typography key="management" color="text.primary" style={{ fontSize: "1em", textWrap: "nowrap" }}>{prefixLabel}</Typography>}
             {pathParts && pathParts.map((p: string, index: number) => {
                 if (index === 0) {
                     p = t("resource.label." + p, p);
                 }
-                if (index === pathParts.length - 1 || (org && index === 0)) {
-                    return <Typography key={index} color="text.primary" style={{ fontSize: "1em" }}>{p}</Typography>
+                if ((index === pathParts.length - 1 && !postfixLabel) || (org && index === 0)) {
+                    return <Typography key={index} color="text.primary" style={{ fontSize: "1em", textWrap: "nowrap" }}>{p}</Typography>
                 }
                 else if (index === pathParts.length - 2 && schemaPath != null && !schemaPath.endsWith("}")) {
                     let subPath = "/ui/resource/view/" + pathParts.slice(0, index + 1).join("/")
-                    return <Link underline="hover" key={index} color="inherit" href="#" onClick={() => {
+                    return <Link underline="hover" key={index} color="inherit" href="#" style={{ textWrap: "nowrap" }} onClick={() => {
                         navigate(subPath);
                     }
                     }>{p}</Link>;
                 }
                 else {
                     let subPath = "/ui/resource/list/" + pathParts.slice(0, index + 1).join("/")
-                    return <Link underline="hover" key={index} color="inherit" href="#" onClick={() => {
+                    return <Link underline="hover" key={index} color="inherit" href="#" style={{ textWrap: "nowrap" }} onClick={() => {
                         navigate(subPath);
                     }
                     }>{p}</Link>;
                 }
             })}
+            {postfixLabel && <Typography key="management" color="text.primary" style={{ fontSize: "1em", textWrap: "nowrap" }}>{postfixLabel}</Typography>}
             {renderFilter()}
         </StyledBreadcrumbs>
         <RestSpinner />

--- a/ui/src/components/pages/parts/Path.tsx
+++ b/ui/src/components/pages/parts/Path.tsx
@@ -9,9 +9,16 @@ import Typography from '@mui/material/Typography';
 import { styled } from '@mui/material';
 import { RestSpinner } from './Rest';
 import { getFilterField, getSchemaPath } from "../../../utils/schema";
-import { TempAny } from "../../../utils/types"
+import { SchemaType } from "../../../utils/types"
 
-function Path({ schema, path, filterValues, org, t }: TempAny) {
+type PathProps = {
+    schema: SchemaType;
+    path: string;
+    filterValues?: string[];
+    org?: string;
+    t: any;
+}
+function Path({ schema, path, filterValues, org, t }: PathProps) {
     const navigate = useNavigate();
 
     const StyledBreadcrumbs = styled(Breadcrumbs)({
@@ -54,7 +61,7 @@ function Path({ schema, path, filterValues, org, t }: TempAny) {
                 if (index === 0) {
                     p = t("resource.label." + p, p);
                 }
-                if (index === pathParts.length - 1 || (org !== "" && index === 0)) {
+                if (index === pathParts.length - 1 || (org && index === 0)) {
                     return <Typography key={index} color="text.primary" style={{ fontSize: "1em" }}>{p}</Typography>
                 }
                 else if (index === pathParts.length - 2 && schemaPath != null && !schemaPath.endsWith("}")) {

--- a/ui/src/components/pages/parts/ResourceHeader.tsx
+++ b/ui/src/components/pages/parts/ResourceHeader.tsx
@@ -4,7 +4,7 @@ import { withTranslation } from "react-i18next";
 import Button from "../../controls/Button";
 import Path from "./Path";
 import { SchemaType } from "../../../utils/types";
-import { getCreatePath } from "../../../utils/schema";
+import { getCreatePath, getSchemaPath } from "../../../utils/schema";
 import EditIcon from '@mui/icons-material/Edit';
 
 type ResourceHeaderProps = {
@@ -22,14 +22,23 @@ function ResourceHeader({ schema, path, type, filterValues, onAction, t }: Resou
     const createLabel = t('button.create.resource', { resource: t("resource.label." + createPathFirstPart + "_one", createPathFirstPart) });
 
     let title;
-    let breadcrumbPath = path;
+    let postfixLabel = undefined;
     if (type === "list") {
-        title = t("resource.label." + createPathFirstPart, createPathFirstPart);
+        if (createPathFirstPart) {
+            title = t("resource.label." + createPathFirstPart, createPathFirstPart);
+        }
+        else {
+            const schemaPathParts = getSchemaPath(schema, path)?.split("/") || [];
+            const lastPart = schemaPathParts[schemaPathParts.length - 1];
+            if (lastPart !== "}") {
+                title = t("resource.label." + lastPart.toLowerCase());
+            }
+        }
     }
     else if (type === "create") {
         const resourceOne = { resources_one: t("resource.label." + createPathFirstPart + "_one", createPathFirstPart) };
         title = t("text.createNewForResource", resourceOne);
-        breadcrumbPath = path + "/" + t("text.newResource", resourceOne);
+        postfixLabel = t("text.newResource", resourceOne);
     }
     else if (type === "view") {
         const resourceOne = { resources_one: t("resource.label." + (path + "/").split("/")[1] + "_one", createPathFirstPart) };
@@ -43,7 +52,7 @@ function ResourceHeader({ schema, path, type, filterValues, onAction, t }: Resou
     return <div className="NuoListResourceHeader">
         <h3>{title}</h3>
         <div>
-            <Path schema={schema} path={breadcrumbPath} filterValues={filterValues} />
+            <Path schema={schema} path={path} prefixLabel={t("list.label.management")} postfixLabel={postfixLabel} filterValues={filterValues} />
             {type === "list" && createPath && <div className="Nuo-p20"><Button data-testid={"list_resource__create_button_" + createPathFirstPart} variant="contained" onClick={onAction}>{createLabel}</Button></div>}
             {type === "view" && <div className="Nuo-p20"><Button data-testid={"list_resource__edit_button"} variant="contained" onClick={onAction}><EditIcon />{t("button.edit")}</Button></div>}
             {type === "create" && <div className="Nuo-p20"><Button data-testid={"create_resource__create_button"} variant="contained" onClick={onAction}><EditIcon />{t("button.create")}</Button></div>}

--- a/ui/src/components/pages/parts/ResourceHeader.tsx
+++ b/ui/src/components/pages/parts/ResourceHeader.tsx
@@ -6,6 +6,9 @@ import Path from "./Path";
 import { SchemaType } from "../../../utils/types";
 import { getCreatePath, getSchemaPath } from "../../../utils/schema";
 import EditIcon from '@mui/icons-material/Edit';
+import AddIcon from '@mui/icons-material/Add';
+import CreateIcon from '@mui/icons-material/Create';
+import SaveIcon from '@mui/icons-material/Save';
 
 type ResourceHeaderProps = {
     schema: SchemaType;
@@ -53,10 +56,10 @@ function ResourceHeader({ schema, path, type, filterValues, onAction, t }: Resou
         <h3>{title}</h3>
         <div>
             <Path schema={schema} path={path} prefixLabel={t("list.label.management")} postfixLabel={postfixLabel} filterValues={filterValues} />
-            {type === "list" && createPath && <div className="Nuo-p20"><Button data-testid={"list_resource__create_button_" + createPathFirstPart} variant="contained" onClick={onAction}>{createLabel}</Button></div>}
+            {type === "list" && createPath && <div className="Nuo-p20"><Button data-testid={"list_resource__create_button_" + createPathFirstPart} variant="contained" onClick={onAction}><AddIcon />{createLabel}</Button></div>}
             {type === "view" && <div className="Nuo-p20"><Button data-testid={"list_resource__edit_button"} variant="contained" onClick={onAction}><EditIcon />{t("button.edit")}</Button></div>}
-            {type === "create" && <div className="Nuo-p20"><Button data-testid={"create_resource__create_button"} variant="contained" onClick={onAction}><EditIcon />{t("button.create")}</Button></div>}
-            {type === "edit" && <div className="Nuo-p20"><Button data-testid={"create_resource__create_button"} variant="contained" onClick={onAction}><EditIcon />{t("button.save")}</Button></div>}
+            {type === "create" && <div className="Nuo-p20"><Button data-testid={"create_resource__create_button"} variant="contained" onClick={onAction}><CreateIcon />{t("button.create")}</Button></div>}
+            {type === "edit" && <div className="Nuo-p20"><Button data-testid={"create_resource__create_button"} variant="contained" onClick={onAction}><SaveIcon />{t("button.save")}</Button></div>}
         </div>
     </div>
 

--- a/ui/src/components/pages/parts/ResourceHeader.tsx
+++ b/ui/src/components/pages/parts/ResourceHeader.tsx
@@ -5,21 +5,21 @@ import Button from "../../controls/Button";
 import Path from "./Path";
 import { SchemaType } from "../../../utils/types";
 import { getCreatePath } from "../../../utils/schema";
-import { useNavigate } from "react-router-dom";
+import EditIcon from '@mui/icons-material/Edit';
 
 type ResourceHeaderProps = {
     schema: SchemaType;
     path: string;
-    type: "list" | "create";
+    type: "list" | "create" | "view" | "edit";
+    onAction: () => void;
     filterValues?: string[];
     t: any;
 }
 
-function ResourceHeader({ schema, path, type, filterValues, t }: ResourceHeaderProps) {
+function ResourceHeader({ schema, path, type, filterValues, onAction, t }: ResourceHeaderProps) {
     const createPath = getCreatePath(schema, path);
     const createPathFirstPart = createPath?.replace(/^\//, "").split("/")[0];
     const createLabel = t('button.create.resource', { resource: t("resource.label." + createPathFirstPart + "_one", createPathFirstPart) });
-    const navigate = useNavigate();
 
     let title;
     let breadcrumbPath = path;
@@ -27,20 +27,27 @@ function ResourceHeader({ schema, path, type, filterValues, t }: ResourceHeaderP
         title = t("resource.label." + createPathFirstPart, createPathFirstPart);
     }
     else if (type === "create") {
-        const data = { resources_one: t("resource.label." + createPathFirstPart + "_one", createPathFirstPart) };
-        title = t("text.createNewForResource", data);
-        breadcrumbPath = path + "/" + t("text.newResource", data);
+        const resourceOne = { resources_one: t("resource.label." + createPathFirstPart + "_one", createPathFirstPart) };
+        title = t("text.createNewForResource", resourceOne);
+        breadcrumbPath = path + "/" + t("text.newResource", resourceOne);
     }
-
-    function handleCreate() {
-        navigate("/ui/resource/create" + path);
+    else if (type === "view") {
+        const resourceOne = { resources_one: t("resource.label." + (path + "/").split("/")[1] + "_one", createPathFirstPart) };
+        title = t("text.viewForResource", resourceOne);
+    }
+    else if (type === "edit") {
+        const resourceOne = { resources_one: t("resource.label." + (path + "/").split("/")[1] + "_one", createPathFirstPart) };
+        title = t("text.editForResource", resourceOne);
     }
 
     return <div className="NuoListResourceHeader">
         <h3>{title}</h3>
         <div>
             <Path schema={schema} path={breadcrumbPath} filterValues={filterValues} />
-            {type === "list" && createPath && <div className="Nuo-p20"><Button data-testid={"list_resource__create_button_" + createPathFirstPart} variant="contained" onClick={handleCreate}>{createLabel}</Button></div>}
+            {type === "list" && createPath && <div className="Nuo-p20"><Button data-testid={"list_resource__create_button_" + createPathFirstPart} variant="contained" onClick={onAction}>{createLabel}</Button></div>}
+            {type === "view" && <div className="Nuo-p20"><Button data-testid={"list_resource__edit_button"} variant="contained" onClick={onAction}><EditIcon />{t("button.edit")}</Button></div>}
+            {type === "create" && <div className="Nuo-p20"><Button data-testid={"create_resource__create_button"} variant="contained" onClick={onAction}><EditIcon />{t("button.create")}</Button></div>}
+            {type === "edit" && <div className="Nuo-p20"><Button data-testid={"create_resource__create_button"} variant="contained" onClick={onAction}><EditIcon />{t("button.save")}</Button></div>}
         </div>
     </div>
 

--- a/ui/src/components/pages/parts/ResourceHeader.tsx
+++ b/ui/src/components/pages/parts/ResourceHeader.tsx
@@ -1,0 +1,49 @@
+// (C) Copyright 2025 Dassault Systemes SE.  All Rights Reserved.
+
+import { withTranslation } from "react-i18next";
+import Button from "../../controls/Button";
+import Path from "./Path";
+import { SchemaType } from "../../../utils/types";
+import { getCreatePath } from "../../../utils/schema";
+import { useNavigate } from "react-router-dom";
+
+type ResourceHeaderProps = {
+    schema: SchemaType;
+    path: string;
+    type: "list" | "create";
+    filterValues?: string[];
+    t: any;
+}
+
+function ResourceHeader({ schema, path, type, filterValues, t }: ResourceHeaderProps) {
+    const createPath = getCreatePath(schema, path);
+    const createPathFirstPart = createPath?.replace(/^\//, "").split("/")[0];
+    const createLabel = t('button.create.resource', { resource: t("resource.label." + createPathFirstPart + "_one", createPathFirstPart) });
+    const navigate = useNavigate();
+
+    let title;
+    let breadcrumbPath = path;
+    if (type === "list") {
+        title = t("resource.label." + createPathFirstPart, createPathFirstPart);
+    }
+    else if (type === "create") {
+        const data = { resources_one: t("resource.label." + createPathFirstPart + "_one", createPathFirstPart) };
+        title = t("text.createNewForResource", data);
+        breadcrumbPath = path + "/" + t("text.newResource", data);
+    }
+
+    function handleCreate() {
+        navigate("/ui/resource/create" + path);
+    }
+
+    return <div className="NuoListResourceHeader">
+        <h3>{title}</h3>
+        <div>
+            <Path schema={schema} path={breadcrumbPath} filterValues={filterValues} />
+            {type === "list" && createPath && <div className="Nuo-p20"><Button data-testid={"list_resource__create_button_" + createPathFirstPart} variant="contained" onClick={handleCreate}>{createLabel}</Button></div>}
+        </div>
+    </div>
+
+}
+
+export default withTranslation()(ResourceHeader);

--- a/ui/src/components/pages/parts/Rest.tsx
+++ b/ui/src/components/pages/parts/Rest.tsx
@@ -210,9 +210,9 @@ export function RestSpinner() {
             onClose={() => instance?.setState({ errorMessage: null })}
         />
         {instance.state.pendingRequests > 0 ?
-            <CircularProgress color="inherit" size="1em" />
+            <CircularProgress className="RestSpinner" color="inherit" />
             :
-            <div data-testid="rest_spinner__complete">&nbsp;</div>
+            <div data-testid="rest_spinner__complete" className="RestSpinner">&nbsp;</div>
         }
     </React.Fragment>;
 }

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -36,9 +36,6 @@ dl.map>div>dt::after {
   font-weight: bold;
 }
 
-.gap {
-  margin: 1em 0;
-}
 .MuiTextField-root {
   display: flex !important;
   flex-direction: column;

--- a/ui/src/resources/translation/de.json
+++ b/ui/src/resources/translation/de.json
@@ -1,21 +1,28 @@
 {
-    "copyright": "(C) Copyright 2024 Dassault Systemes SE.  All Rights Reserved.",
+    "copyright": "(C) Copyright 2024-2025 Dassault Systemes SE.  All Rights Reserved.",
     "button": {
         "create": "Erstellen",
         "create.resource": "{{resource}} erstellen",
         "delete": "Löschen",
         "edit": "Bearbeiten",
-        "search": "Suchen",
         "save": "Speichern",
         "yes": "Ja",
         "no": "Nein",
+        "ok": "Ok",
+        "cancel": "Abbrechen",
+        "true": "Richtig",
+        "false": "Falsch",
+        "db.connection.info": "Datenbankverbindung anzeigen",
         "start.database": "Datenbank starten",
         "stop.database": "Datenbak stoppen",
         "show.databases": "Datenbanken anzeigen",
         "show.backups": "Sicherungen anzeigen",
         "settings": "Einstellungen",
+        "automation": "Automatisierung",
         "logout": "Ausloggen",
-        "add": "Hinzufügen"
+        "add": "Hinzufügen",
+        "copy": "Kopieren",
+        "copied": "Kopiert!"
     },
     "hint": {
         "open.settings": "Einstellungen öffnen"
@@ -30,7 +37,9 @@
         "stop.database.title": "Datenbank stoppen",
         "stop.database.body": "Möchten sie die Datenbank {{organization}}/{{project}}/{{name}} stoppen?",
         "delete.resource.title": "{{resources_one}} {{name}} löschen",
-        "delete.resource.body": "Wollen sie wirklich die {{resources_one}} {{name}} löschen?"
+        "delete.resource.body": "Wollen sie wirklich die {{resources_one}} {{name}} löschen?",
+        "delete.resources.title": "{{count}} {{resources}} löschen",
+        "delete.resources.body": "Bitte bestätigen sie die löschung der {{resources}} {{names}}?"
     },
     "resource": {
         "label": {
@@ -64,7 +73,39 @@
             "state": "Status",
             "database": "Datenbank",
             "frequency": "Frequenz",
-            "selector": "Auswahl"
+            "selector": "Auswahl",
+            "selector.scope": "Scope",
+            "selector.slas": "SLAs",
+            "selector.tiers": "Tiers",
+            "selector.labels": "Labels",
+            "maintenance.expiresAtTime": "Läuft ab am",
+            "maintenance.expiresIn": "Läuft ab in",
+            "properties.propagatePolicyLabels": "Richtlinien labels verbreiten",
+            "properties.propagateDatabaseLabels": "Datenbank labels verbreiten",
+            "properties.archiveDiskSize": "Archiv Speichergröße",
+            "properties.journalDiskSize": "Journal Speichergröße",
+            "properties.tierParameters": "Tier Einstellungen",
+            "properties.inheritTierParameters": "Tier Einstellungen übernehmen",
+            "properties.productVersion": "Product Version",
+            "retention": "Beibehaltung",
+            "retention.hourly": "Stündlich",
+            "retention.daily": "Täglich",
+            "retention.weekly": "Wöchentlich",
+            "retention.monthly": "Monatlich",
+            "retention.yearly": "Jährlich",
+            "retention.settings.dayOfWeek": "Wochentag",
+            "retention.settings.month": "Monat",
+            "retention.settings.relativeToLast": "Abhängig von letzter Sicherung",
+            "retention.settings.promoteLatestToHourly": "Übernehme letzes zu stündlich",
+            "retention.settings.promoteLatestToDaily": "Übernehme letzes zu täglich",
+            "retention.settings.promoteLatestToMonthly": "Übernehme letzes zu monatlich"
+        },
+        "crontab": {
+            "minute": "Minute",
+            "hour": "Stunde",
+            "dayOfMonth": "Monatstag",
+            "month": "Monat",
+            "weekday": "Wochentag"
         },
         "enum": {
             "theme.material": "Material UI",
@@ -102,7 +143,13 @@
             "hint.new.value": "Neuer Wert"
         },
         "select": {
-            "selectItem": "--- Eintrag auswählen ---"
+            "selectItem": "--- Eintrag auswählen ---",
+            "allOrgs": "Alle Organisationen"
+        }
+    },
+    "list": {
+        "label": {
+            "management": "Management"
         }
     },
     "form": {
@@ -112,9 +159,37 @@
             }
         }
     },
+    "dialog": {
+        "dbConnectionInfo": {
+            "title": "Datenbankverbindung Information für {{dbName}}",
+            "label": {
+                "database": "Datenbank",
+                "sqlEndpoint": "SQL Addresse",
+                "certificate": "Zertifikat",
+                "codeSamples": "Code Beispiel",
+                "description": "Folgende Beispiele benötigen die \"NuoDB client library\" welche von [hier](https://github.com/nuodb/nuodb-client/releases) heruntergeladen werden kann. Füllen sie den Benutzernamen/Kennwort für die Datenbank aus und starten sie die Beispiele von dem extrahierten Verzeichnis der \"NuoDB Client Library\".",
+                "nuosql": "Kommandozeile (nuosql)",
+                "jdbc": "Java (JDBC)",
+                "cpp": "C++"
+            }
+        },
+        "automation": {
+            "title": "Automatisierung",
+            "curl": "Aufnahme als CURL Anweisungen exportieren",
+            "startRecording": "Neue Aufnahme starten",
+            "stopRecording": "Aufnahme beenden",
+            "recordingInProgress": "Aufnahme läuft...",
+            "hideGetRequests": "GET Anweisungen ausblenden",
+            "convertUpdatesToPatchRequests": "PUT Anweisungen zu PATCH umwandeln",
+            "noWriteRequests": "Keine Änderungen aufgenommen."
+        }
+    },
     "text": {
         "editEntryForPath": "Eintrag für {{path}} bearbeiten",
-        "createEntryForPath": "Eintrag für {{path}} erstellen",
+        "createNewForResource": "Neue {{resources_one}} erstellen",
+        "viewForResource": "{{resources_one}}",
+        "editForResource": "{{resources_one}} bearbeiten",
+        "newResource": "{{resources_one}} erstellen",
         "noData": "Keine Daten"
     },
     "section": {
@@ -126,5 +201,36 @@
             "database.selection": "Datenbank Auswahl",
             "database.retention": "Datenbank beibehalten"
         }
-    }
+    },
+    "calendar": {
+        "timezone": "Zeitzone",
+        "time": "Zeit",
+        "am": "Vormittags",
+        "pm": "Nachmittags",
+        "timezone.local": "Örtliche Zeit",
+        "timezone.utc": "UTC Zeit",
+        "dayOfWeek": {
+            "Sunday": "Sonntag",
+            "Monday": "Motag",
+            "Tuesday": "Dienstag",
+            "Wednesday": "Mittwoch",
+            "Thursday": "Donnerstag",
+            "Friday": "Freitag",
+            "Saturday": "Samstag"
+        },
+        "month": {
+            "January": "Januar",
+            "February": "Februar",
+            "March": "März",
+            "April": "April",
+            "May": "Mai",
+            "June": "Juni",
+            "July": "Juli",
+            "August": "August",
+            "September": "September",
+            "October": "Oktober",
+            "November": "November",
+            "December": "Dezember"
+        }
+}
 }

--- a/ui/src/resources/translation/en.json
+++ b/ui/src/resources/translation/en.json
@@ -187,6 +187,8 @@
     "text": {
         "editEntryForPath": "Edit entry for {{path}}",
         "createNewForResource": "Create new {{resources_one}}",
+        "viewForResource": "{{resources_one}}",
+        "editForResource": "Edit {{resources_one}}",
         "newResource": "New {{resources_one}}",
         "noData": "No Data"
     },

--- a/ui/src/resources/translation/en.json
+++ b/ui/src/resources/translation/en.json
@@ -186,11 +186,13 @@
     },
     "text": {
         "editEntryForPath": "Edit entry for {{path}}",
-        "createEntryForPath": "Create entry for {{path}}",
+        "createNewForResource": "Create new {{resources_one}}",
+        "newResource": "New {{resources_one}}",
         "noData": "No Data"
     },
     "section": {
         "title": {
+            "general": "General",
             "advanced": "Advanced",
             "access.deny.rules": "Access/Deny Rules",
             "labels": "Labels",


### PR DESCRIPTION
- moved wait spinner to 30% height overlaying everything and made a bit bigger.
- changed first layer collapsible sections to a tab layout. I kept the second layer collapsible sections as is to avoid confusion with second layer tabs
- removed form help description since it is almost identical to the new form title.
- split out breadcrumbs and title into separate "ResourceHeader" component
- combined query fields with "General" fields
- added a prefix/postfix text to the <Path/> component, so proper "Management" and "New Database" are shown in the breadcrumbs
- updated German translation
