### PR TITLE
show field validation errors on other form tabs

### DIFF
--- a/ui/public/theme/base.css
+++ b/ui/public/theme/base.css
@@ -824,7 +824,8 @@ button:focus {
 
 .NuoTabs>ul>li {
     display: flex;
-    flex-direction: column;
+    flex-direction: row;
+        align-items: center;
     background-color: #fff;
     color: rgba(0, 0, 0, 0.87);
     padding: 10px;
@@ -860,4 +861,14 @@ button:focus {
 }
 .NuoFieldContainer {
     margin: .5em 0;
+}
+.NuoBadge {
+    min-width: 10px;
+    min-height: 10px;
+    background-color: red;
+    margin: 0 0 0 5px;
+    border-radius: 99999px;
+    padding: 3px;
+    font-size: 13px;
+    color: white;
 }

--- a/ui/src/components/controls/Tabs.tsx
+++ b/ui/src/components/controls/Tabs.tsx
@@ -1,6 +1,6 @@
 // (C) Copyright 2024 Dassault Systemes SE.  All Rights Reserved.
 
-import { ReactElement, ReactNode, useState } from "react"
+import { ReactElement, ReactNode } from "react"
 
 type TabProps = {
     id: string;
@@ -14,11 +14,12 @@ export function Tab({ children }: TabProps) {
 
 type TabsProps = {
     children: ReactElement[];
+    currentTab: number;
+    setCurrentTab: (tab: number) => void;
 }
 
-export function Tabs({ children }: TabsProps) {
+export function Tabs({ children, currentTab, setCurrentTab }: TabsProps) {
     children = children.filter(child => child.props.id && child.props.label && child.props.children);
-    const [currentTab, setCurrentTab] = useState<number>(0);
 
     return <div className="NuoTabs">
         <ul>{children.map((child, index) => (

--- a/ui/src/components/controls/Tabs.tsx
+++ b/ui/src/components/controls/Tabs.tsx
@@ -16,9 +16,14 @@ type TabsProps = {
     children: ReactElement[];
     currentTab: number;
     setCurrentTab: (tab: number) => void;
+    badges?: { [key: number]: number };
 }
 
-export function Tabs({ children, currentTab, setCurrentTab }: TabsProps) {
+function badge(count: number) {
+    return <div className="NuoBadge">{count < 0 ? "" : count}</div>
+}
+
+export function Tabs({ children, currentTab, setCurrentTab, badges }: TabsProps) {
     children = children.filter(child => child.props.id && child.props.label && child.props.children);
 
     return <div className="NuoTabs">
@@ -29,7 +34,7 @@ export function Tabs({ children, currentTab, setCurrentTab }: TabsProps) {
                     setCurrentTab(index);
                 }}
             >
-                {child.props.label}
+                {child.props.label}{badges && (index in badges) && badge(badges[index])}
             </li>))}
             <li style={{ display: "flex", flex: "1 1 auto" }}></li>
         </ul>

--- a/ui/src/components/fields/FieldCrontab.tsx
+++ b/ui/src/components/fields/FieldCrontab.tsx
@@ -95,6 +95,9 @@ export default function FieldCrontab(props: FieldProps): FieldBaseType {
         if (!prefix) {
             prefix = props.prefix;
         }
+        if (!parameter) {
+            parameter = props.parameter;
+        }
         if (value === undefined) {
             value = getValue(values, prefix);
         }


### PR DESCRIPTION
originally field validation errors could have been shown on tabs which are not selected and therefore invisible to the user when they click the "create" or "save" buttons on the form. Now it will automatically switch to the first tab having an error. Because of delayed state changes I had to keep track of the errors during the validation phase.