### PR TITLE
fix helm deployment

### DIFF
--- a/build_utils.sh
+++ b/build_utils.sh
@@ -107,9 +107,7 @@ function uploadHelmPackage() {
     fi
 
     helm push build/charts/nuodbaas-webui-*-latest.tgz "oci://${ECR_ACCOUNT_URL}"
-    rm build/charts/nuodbaas-webui-*-latest.tgz
-    helm push build/charts/nuodbaas-webui-*.tgz "oci://${ECR_ACCOUNT_URL}"
-    rm build/charts/nuodbaas-webui-*.tgz
+    helm push build/charts/nuodbaas-webui-*+*.tgz "oci://${ECR_ACCOUNT_URL}"
 
     # Checkout gh-pages and fast forward to origin
     git checkout gh-pages

--- a/build_utils.sh
+++ b/build_utils.sh
@@ -106,7 +106,10 @@ function uploadHelmPackage() {
         return 0
     fi
 
-    helm push build/charts/nuodbaas-webui-*.tgz "oci://${ECR_ACCOUNT_URL}/"
+    helm push build/charts/nuodbaas-webui-*-latest.tgz "oci://${ECR_ACCOUNT_URL}"
+    rm build/charts/nuodbaas-webui-*-latest.tgz
+    helm push build/charts/nuodbaas-webui-*.tgz "oci://${ECR_ACCOUNT_URL}"
+    rm build/charts/nuodbaas-webui-*.tgz
 
     # Checkout gh-pages and fast forward to origin
     git checkout gh-pages


### PR DESCRIPTION
there are two helm versions for each merged build:
- nuodbaas-webui-<version>-latest.tgz
- nuodbaas-webui-<version>-<helm-sha>+<git-sha>.tgz
and both need to be deployed to the helm chart registry. Before this change both files were included in the `helm push` command which of course didn't work.