### PR TITLE
Fix service account creation

### DIFF
--- a/charts/nuodbaas-webui/templates/ingress.yaml
+++ b/charts/nuodbaas-webui/templates/ingress.yaml
@@ -1,5 +1,5 @@
 # (C) Copyright 2024-2025 Dassault Systemes SE.  All Rights Reserved.
-{{- if .Values.nuodbaasWebui.ingress.enabled -}}
+{{- if .Values.nuodbaasWebui.ingress.enabled }}
 {{- $fullName := include "nuodbaas-webui.fullname" . -}}
 {{- $svcPort := .Values.nuodbaasWebui.service.port -}}
 {{- if and .Values.nuodbaasWebui.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
@@ -7,7 +7,7 @@
   {{- $_ := set .Values.nuodbaasWebui.ingress.annotations "kubernetes.io/ingress.class" .Values.nuodbaasWebui.ingress.className }}
   {{- end }}
 {{- end }}
-{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" -}}
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
 apiVersion: networking.k8s.io/v1
 {{- else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/Ingress" -}}
 apiVersion: networking.k8s.io/v1beta1

--- a/charts/nuodbaas-webui/templates/serviceaccount.yaml
+++ b/charts/nuodbaas-webui/templates/serviceaccount.yaml
@@ -1,5 +1,5 @@
 # (C) Copyright 2025 Dassault Systemes SE.  All Rights Reserved.
-{{- if .Values.serviceAccount.create -}}
+{{- if .Values.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:


### PR DESCRIPTION
**Issue**

Helm rendering is broken if the service account is enabled.
The issue is exposed by adding a copyright comment to `nuodbaas-webui/templates/serviceaccount.yaml` file.

```
╷
│ Error: unable to build kubernetes objects from release manifest: error validating "": error validating data: apiVersion not set
│ 
│   with helm_release.nuodbaas_webui,
│   on main.tf line 15, in resource "helm_release" "nuodbaas_webui":
│   15: resource "helm_release" "nuodbaas_webui" {
```

```
$ helm template nuodbaas-webui nuodbaas-webui | grep -B2 apiVersion
---
# Source: nuodbaas-webui/templates/serviceaccount.yaml
# (C) Copyright 2025 Dassault Systemes SE.  All Rights Reserved.apiVersion: v1
--
```

**Changes**

Do not omit new lines in several templates.