### PR TITLE
fix selections on view changes + use non-admin for integration tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,6 +73,11 @@ setup-integration-tests: build-image install-crds ## setup containers before run
 		--data-binary \
             '{\"password\":\"passw0rd\", \"name\":\"admin\", \"organization\": \"acme\", \"accessRule\":{\"allow\": \"all:*\"}}' \
 		-X PUT -H \"Content-Type: application/json\" > /dev/null"
+	@docker exec selenium-tests-nuodb-cp-1 bash -c "curl \
+		http://localhost:8080/users/integrationtest/admin \
+		--data-binary \
+            '{\"password\":\"passw0rd\", \"name\":\"admin\", \"organization\": \"integrationtest\", \"accessRule\":{\"allow\": \"all:integrationtest\"}}' \
+		-X PUT -H \"Content-Type: application/json\" > /dev/null"
 
 .PHONY: teardown-integration-tests
 teardown-integration-tests: $(KWOKCTL) ## clean up containers used by integration tests

--- a/build_utils.sh
+++ b/build_utils.sh
@@ -191,8 +191,8 @@ if [ "$1" == "createRelease" ] && [ "$2" != "" ] ; then
         docker pull "${GIT_DOCKER_IMAGE_SHA}" && \
         docker tag "${GIT_DOCKER_IMAGE_SHA}" "${AWS_DOCKER_IMAGE_RELEASE}" && \
         docker tag "${GIT_DOCKER_IMAGE_SHA}" "${GIT_DOCKER_IMAGE_RELEASE}" && \
-        docker push "${AWS_DOCKER_IMAGE_RELEASE} && \
-        docker push "${GIT_DOCKER_IMAGE_RELEASE} && \
+        docker push "${AWS_DOCKER_IMAGE_RELEASE}" && \
+        docker push "${GIT_DOCKER_IMAGE_RELEASE}" && \
         \
         mkdir -p build && \
         rm -rf build/charts && \

--- a/selenium-tests/src/test/java/com/nuodb/selenium/Constants.java
+++ b/selenium-tests/src/test/java/com/nuodb/selenium/Constants.java
@@ -1,9 +1,0 @@
-// (C) Copyright 2024 Dassault Systemes SE.  All Rights Reserved.
-
-package com.nuodb.selenium;
-
-public class Constants {
-    public static final String ADMIN_ORGANIZATION = "acme";
-    public static final String ADMIN_USER = "admin";
-    public static final String ADMIN_PASSWORD = "passw0rd";
-}

--- a/selenium-tests/src/test/java/com/nuodb/selenium/advanced/RandomClicks.java
+++ b/selenium-tests/src/test/java/com/nuodb/selenium/advanced/RandomClicks.java
@@ -3,7 +3,6 @@ package com.nuodb.selenium.advanced;
 
 import org.junit.jupiter.api.Test;
 
-import com.nuodb.selenium.Constants;
 import com.nuodb.selenium.TestRoutines;
 import com.nuodb.selenium.basic.BannerTest;
 
@@ -11,7 +10,7 @@ public class RandomClicks extends TestRoutines {
 
     @Test
     public void testRandomClicks() {
-        login(Constants.ADMIN_ORGANIZATION, Constants.ADMIN_USER, Constants.ADMIN_PASSWORD);
+        login();
         for(int i=0; i<3; i++) {
             String projectName = createProject();
             String databaseName = createDatabase(projectName);

--- a/selenium-tests/src/test/java/com/nuodb/selenium/basic/AutomationTest.java
+++ b/selenium-tests/src/test/java/com/nuodb/selenium/basic/AutomationTest.java
@@ -7,7 +7,6 @@ import org.junit.jupiter.api.Test;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.nuodb.selenium.Constants;
 import com.nuodb.selenium.TestRoutines;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -16,7 +15,7 @@ public class AutomationTest extends TestRoutines {
     @Test
     public void testRecordingCreateAndDeleteUsers() throws JsonProcessingException {
         // Start Recording
-        login(Constants.ADMIN_ORGANIZATION, Constants.ADMIN_USER, Constants.ADMIN_PASSWORD);
+        login();
         clickUserMenu("automation");
         clearSessionStorage("nuodbaas-webui-recorded");
         clearSessionStorage("nuodbaas-webui-isRecording");

--- a/selenium-tests/src/test/java/com/nuodb/selenium/basic/BackupTest.java
+++ b/selenium-tests/src/test/java/com/nuodb/selenium/basic/BackupTest.java
@@ -4,7 +4,6 @@ package com.nuodb.selenium.basic;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.WebElement;
 
-import com.nuodb.selenium.Constants;
 import com.nuodb.selenium.TestRoutines;
 
 import static com.nuodb.selenium.SeleniumAssert.assertThat;
@@ -17,7 +16,7 @@ import java.util.List;
 public class BackupTest extends TestRoutines {
     @Test
     public void testCreateBackup() throws MalformedURLException {
-        login(Constants.ADMIN_ORGANIZATION, Constants.ADMIN_USER, Constants.ADMIN_PASSWORD);
+        login();
         String projectName = createProject();
         String databaseName = createDatabase(projectName);
         String backupName = createBackup(projectName, databaseName);
@@ -30,7 +29,7 @@ public class BackupTest extends TestRoutines {
     @Test
     public void testListCreateAndDeleteBackups() {
         // Setup and list Backups
-        login(Constants.ADMIN_ORGANIZATION, Constants.ADMIN_USER, Constants.ADMIN_PASSWORD);
+        login();
         String projectName = createProject();
         String databaseName = createDatabase(projectName);
         String backupName = createBackup(projectName, databaseName);
@@ -49,7 +48,7 @@ public class BackupTest extends TestRoutines {
     @Test
     public void testEditBackup() {
         // Setup and list backups
-        login(Constants.ADMIN_ORGANIZATION, Constants.ADMIN_USER, Constants.ADMIN_PASSWORD);
+        login();
         String projectName = createProject();
         String databaseName = createDatabase(projectName);
         String backupName = createBackup(projectName, databaseName);

--- a/selenium-tests/src/test/java/com/nuodb/selenium/basic/BannerTest.java
+++ b/selenium-tests/src/test/java/com/nuodb/selenium/basic/BannerTest.java
@@ -5,7 +5,6 @@ package com.nuodb.selenium.basic;
 import org.junit.jupiter.api.Test;
 
 import com.google.common.collect.ImmutableList;
-import com.nuodb.selenium.Constants;
 import com.nuodb.selenium.TestRoutines;
 
 import java.net.MalformedURLException;
@@ -16,7 +15,7 @@ public class BannerTest extends TestRoutines {
 
     @Test
     public void testMenuBanner() throws MalformedURLException {
-        login(Constants.ADMIN_ORGANIZATION, Constants.ADMIN_USER, Constants.ADMIN_PASSWORD);
+        login();
 
         // make sure all menu items are present
         for(String menuItem : expectedMenuItems) {

--- a/selenium-tests/src/test/java/com/nuodb/selenium/basic/DatabaseTest.java
+++ b/selenium-tests/src/test/java/com/nuodb/selenium/basic/DatabaseTest.java
@@ -5,7 +5,6 @@ package com.nuodb.selenium.basic;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.WebElement;
 
-import com.nuodb.selenium.Constants;
 import com.nuodb.selenium.TestRoutines;
 
 import static com.nuodb.selenium.SeleniumAssert.assertThat;
@@ -19,7 +18,7 @@ import java.util.List;
 public class DatabaseTest extends TestRoutines {
     @Test
     public void testCreateDatabase() throws MalformedURLException {
-        login(Constants.ADMIN_ORGANIZATION, Constants.ADMIN_USER, Constants.ADMIN_PASSWORD);
+        login();
         String projectName = createProject();
         String databaseName = createDatabase(projectName);
 
@@ -31,7 +30,7 @@ public class DatabaseTest extends TestRoutines {
     @Test
     public void testListCreateAndDeleteDatabases() {
         // Setup and list databases
-        login(Constants.ADMIN_ORGANIZATION, Constants.ADMIN_USER, Constants.ADMIN_PASSWORD);
+        login();
         String projectName = createProject();
         String databaseName = createDatabase(projectName);
 
@@ -49,7 +48,7 @@ public class DatabaseTest extends TestRoutines {
     @Test
     public void testEditDatabase() {
         // Setup and list databases
-        login(Constants.ADMIN_ORGANIZATION, Constants.ADMIN_USER, Constants.ADMIN_PASSWORD);
+        login();
         String projectName = createProject();
         String databaseName = createDatabase(projectName);
 
@@ -77,7 +76,7 @@ public class DatabaseTest extends TestRoutines {
    @Test
    public void testStartStopDatabase() {
        // Setup and list databases
-       login(Constants.ADMIN_ORGANIZATION, Constants.ADMIN_USER, Constants.ADMIN_PASSWORD);
+       login();
        String projectName = createProject();
        String databaseName = createDatabase(projectName);
 

--- a/selenium-tests/src/test/java/com/nuodb/selenium/basic/ListResourceTest.java
+++ b/selenium-tests/src/test/java/com/nuodb/selenium/basic/ListResourceTest.java
@@ -6,7 +6,6 @@ import org.junit.jupiter.api.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 
-import com.nuodb.selenium.Constants;
 import com.nuodb.selenium.TestRoutines;
 
 
@@ -18,7 +17,7 @@ public class ListResourceTest extends TestRoutines {
     @Test
     public void testDeleteMultipleUsers() {
         // Setup and list users
-        login(Constants.ADMIN_ORGANIZATION, Constants.ADMIN_USER, Constants.ADMIN_PASSWORD);
+        login();
         String userNames[] = { createUser(), createUser() };
         clickMenu("users");
 

--- a/selenium-tests/src/test/java/com/nuodb/selenium/basic/LoginTest.java
+++ b/selenium-tests/src/test/java/com/nuodb/selenium/basic/LoginTest.java
@@ -6,7 +6,6 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import com.nuodb.selenium.Constants;
 import com.nuodb.selenium.TestRoutines;
 
 import java.net.MalformedURLException;
@@ -31,6 +30,6 @@ public class LoginTest extends TestRoutines {
 
     @Test
     public void testLogin() throws MalformedURLException {
-        login(Constants.ADMIN_ORGANIZATION, Constants.ADMIN_USER, Constants.ADMIN_PASSWORD);
+        login();
     }
 }

--- a/selenium-tests/src/test/java/com/nuodb/selenium/basic/ProjectTest.java
+++ b/selenium-tests/src/test/java/com/nuodb/selenium/basic/ProjectTest.java
@@ -5,7 +5,6 @@ package com.nuodb.selenium.basic;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.WebElement;
 
-import com.nuodb.selenium.Constants;
 import com.nuodb.selenium.TestRoutines;
 
 import static com.nuodb.selenium.SeleniumAssert.assertThat;
@@ -18,14 +17,14 @@ import java.util.List;
 public class ProjectTest extends TestRoutines {
     @Test
     public void testCreateProject() throws MalformedURLException {
-        login(Constants.ADMIN_ORGANIZATION, Constants.ADMIN_USER, Constants.ADMIN_PASSWORD);
+        login();
         createProject();
     }
 
     @Test
     public void testListCreateAndDeleteProjects() {
         // Setup and list projects
-        login(Constants.ADMIN_ORGANIZATION, Constants.ADMIN_USER, Constants.ADMIN_PASSWORD);
+        login();
         String projectName = createProject();
         clickMenu("projects");
 
@@ -44,7 +43,7 @@ public class ProjectTest extends TestRoutines {
     @Test
     public void testEditProject() {
         // Setup and list projects
-        login(Constants.ADMIN_ORGANIZATION, Constants.ADMIN_USER, Constants.ADMIN_PASSWORD);
+        login();
         String projectName = createProject();
 
         // resource versions are getting updated in the background a few times by the control plane / operator preventing an update later.

--- a/selenium-tests/src/test/java/com/nuodb/selenium/basic/SearchTest.java
+++ b/selenium-tests/src/test/java/com/nuodb/selenium/basic/SearchTest.java
@@ -6,7 +6,6 @@ import org.junit.jupiter.api.Test;
 import org.openqa.selenium.Keys;
 import org.openqa.selenium.WebElement;
 
-import com.nuodb.selenium.Constants;
 import com.nuodb.selenium.TestRoutines;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -18,26 +17,27 @@ public class SearchTest extends TestRoutines {
     @Test
     public void testSearch() throws IOException {
         String body = """
-            {"organization":"acme",
+            {"organization":"%%%TEST_ORGANIZATION%%%",
                 "name": "%%%NAME%%%",
                 "password": "passw0rd",
-                "accessRule": {"allow": "all:acme"},
+                "accessRule": {"allow": "all:%%%TEST_ORGANIZATION%%%"},
                 "labels": {
                     "label1": "value1",
                     "label2": "%%%VALUE2%%%"
                 }
             }
         """;
+        body = body.replaceAll("%%%TEST_ORGANIZATION%%%", TEST_ORGANIZATION);
 
         // Setup users
         String name = shortUnique("u");
         for(int i=10; i<=99; i++) {
-            System.out.println("Creating user /acme/" + (name + i));
-            createResourceRest(Resource.users, "/acme/" + (name + i), body.replaceAll("%%%NAME%%%", name + i).replaceAll("%%%VALUE2%%%", (name + (i%10))));
+            System.out.println("Creating user /" + TEST_ORGANIZATION + "/" + (name + i));
+            createResourceRest(Resource.users, "/" + TEST_ORGANIZATION + "/" + (name + i), body.replaceAll("%%%NAME%%%", name + i).replaceAll("%%%VALUE2%%%", (name + (i%10))));
         }
 
         // verify we have full page of users
-        login(Constants.ADMIN_ORGANIZATION, Constants.ADMIN_USER, Constants.ADMIN_PASSWORD);
+        login();
         clickMenu("users");
         waitRestComplete();
         retry(()->{

--- a/selenium-tests/src/test/java/com/nuodb/selenium/basic/UserTest.java
+++ b/selenium-tests/src/test/java/com/nuodb/selenium/basic/UserTest.java
@@ -5,7 +5,6 @@ package com.nuodb.selenium.basic;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.WebElement;
 
-import com.nuodb.selenium.Constants;
 import com.nuodb.selenium.TestRoutines;
 
 import static com.nuodb.selenium.SeleniumAssert.assertThat;
@@ -19,14 +18,14 @@ import java.util.List;
 public class UserTest extends TestRoutines {
     @Test
     public void testCreateUser() throws MalformedURLException {
-        login(Constants.ADMIN_ORGANIZATION, Constants.ADMIN_USER, Constants.ADMIN_PASSWORD);
+        login();
         createUser();
     }
 
     @Test
     public void testListCreateAndDeleteUsers() {
         // Setup and list users
-        login(Constants.ADMIN_ORGANIZATION, Constants.ADMIN_USER, Constants.ADMIN_PASSWORD);
+        login();
         String userName = createUser();
         clickMenu("users");
 
@@ -44,7 +43,7 @@ public class UserTest extends TestRoutines {
     @Test
     public void testEditUser() {
         // Setup and list users
-        login(Constants.ADMIN_ORGANIZATION, Constants.ADMIN_USER, Constants.ADMIN_PASSWORD);
+        login();
         String userName = createUser();
         clickMenu("users");
 

--- a/selenium-tests/src/test/java/com/nuodb/selenium/smoke/ResourcesTest.java
+++ b/selenium-tests/src/test/java/com/nuodb/selenium/smoke/ResourcesTest.java
@@ -1,0 +1,24 @@
+// (C) Copyright 2025 Dassault Systemes SE.  All Rights Reserved.
+
+package com.nuodb.selenium.smoke;
+
+import org.junit.jupiter.api.Test;
+
+import com.nuodb.selenium.TestRoutines;
+
+import java.net.MalformedURLException;
+
+public class ResourcesTest extends TestRoutines {
+    @Test
+    public void testCreateUser() throws MalformedURLException {
+        login();
+        String user = createUser();
+        String project = createProject();
+        String db = createDatabase(project);
+        String backup = createBackup(project, db);
+        deleteBackup(backup);
+        deleteDatabase(db);
+        deleteProject(project);
+        deleteUser(user);
+    }
+}

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -41,7 +41,7 @@ export default function App() {
     }
 
     // get orgs by scanning all accessible users and projects
-    Promise.all([Rest.get("/users"), Rest.get("/projects")]).then((usersAndProjects: any[]) => {
+    Promise.all([Rest.get("/users?listAccessible=true"), Rest.get("/projects?listAccessible=true")]).then((usersAndProjects: any[]) => {
       const data: any = [...usersAndProjects[0].items, ...usersAndProjects[1].items];
       let orgs: string[] = [];
       data.forEach((item: string) => {
@@ -51,22 +51,19 @@ export default function App() {
         }
       });
       setOrgs(orgs);
-      if (orgs.length === 1) {
-        setOrg(orgs[0]);
-      }
-      else {
-        // get selected org from URL path
-        let org = "";
-        let path = window.location.pathname;
-        if (path.startsWith("/ui/resource/")) {
-          path = path.substring("/ui/resource/".length);
-          const posSlash = path.indexOf("/");
-          if (posSlash !== -1) {
-            org = getOrgFromPath(schema, path.substring(posSlash));
-          }
+
+      // get selected org from URL path
+      let org = "";
+      let path = window.location.pathname;
+      if (path.startsWith("/ui/resource/")) {
+        path = path.substring("/ui/resource/".length);
+        const posSlash = path.indexOf("/");
+        if (posSlash !== -1) {
+          org = getOrgFromPath(schema, path.substring(posSlash));
         }
-        setOrg(org);
       }
+      setOrg(org);
+
     });
   }, [schema, isLoggedIn]);
 

--- a/ui/src/components/pages/parts/Table.tsx
+++ b/ui/src/components/pages/parts/Table.tsx
@@ -99,6 +99,10 @@ function Table(props: TableProps) {
         setColumns(cols);
     }, [data, path, schema, t]);
 
+    useEffect(() => {
+        setSelected(new Set<string>());
+    }, [path, schema]);
+
     type TableLabelsType = {
         [key: string]: string
     }
@@ -177,6 +181,7 @@ function Table(props: TableProps) {
                     Rest.toastError("Unable to delete " + editDeletePaths[index], result.reason);
                 }
             })
+            setSelected(new Set());
         }
     }
 
@@ -330,7 +335,7 @@ function Table(props: TableProps) {
                     type="checkbox"
                     data-testid="check_all"
                     checked={selected.size === data.length}
-                    onChange={(event) => {
+                    onChange={() => {
                         let allSelected = selected.size === data.length;
                         if (allSelected) {
                             setSelected(new Set());


### PR DESCRIPTION
- fixes issue where selections of view items (check boxes) are not cleared when switching views (i.e. from users to projects view).
- fix typo on script to create a release
- adjust integration tests to use a non-admin user for execution
- fix a few URL's to allow for non-admin users to return results if the organization is not specified
- don't default to an org if only one org is available (before it prevented an admin from creating a user in a new org)