### PR TITLE
move WebUI to /ui prefix

### DIFF
--- a/charts/nuodbaas-webui/README.md
+++ b/charts/nuodbaas-webui/README.md
@@ -25,6 +25,7 @@ All configurable parameters for each top-level scope are detailed below, organiz
 | `nuodbaasWebui.resources.requests.memory` | Specify memory requests | `128Mi` |
 | `nuodbaasWebui.service.type` | Specify service type | `ClusterIP` |
 | `nuodbaasWebui.pathPrefix` | Specify NuoDBaaS WebUI prefix | `ui` |
+| `nuodbaasWebui.pathPrefixAlternate` | Specify alternate NuoDBaaS WebUI prefix | `webui` |
 | `nuodbaasWebui.cpUrl` | The URL used to send requests to the Control Plane REST service | `/nuodb-cp` |
 
 ## Uninstalling the Chart

--- a/charts/nuodbaas-webui/templates/ingress.yaml
+++ b/charts/nuodbaas-webui/templates/ingress.yaml
@@ -47,16 +47,22 @@ spec:
     {{- include "nuodbaas-webui.ingress.backend" . | nindent 4 }}
   {{- end }}
   rules:
-    {{- with .Values.nuodbaasWebui.ingress.pathPrefix }}
     - http:
         paths:
-          - path: /{{ . }}
+          - path: /{{ .Values.nuodbaasWebui.ingress.pathPrefix }}
             {{- if semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion }}
             pathType: Prefix
             {{- end }}
             backend:
               {{- include "nuodbaas-webui.ingress.backend" $ | nindent 14 }}
-    {{- end }}
+          {{- if .Values.nuodbaasWebui.ingress.pathPrefixAlternate }}
+          - path: /{{ .Values.nuodbaasWebui.ingress.pathPrefixAlternate }}
+            {{- if semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion }}
+            pathType: Prefix
+            {{- end }}
+            backend:
+              {{- include "nuodbaas-webui.ingress.backend" $ | nindent 14 }}
+          {{- end }}
     {{- range .Values.nuodbaasWebui.ingress.hosts }}
     - host: {{ .host | quote }}
       http:

--- a/charts/nuodbaas-webui/values.yaml
+++ b/charts/nuodbaas-webui/values.yaml
@@ -101,7 +101,8 @@ nuodbaasWebui:
       # kubernetes.io/ingress.class: haproxy
       # ingress.kubernetes.io/ssl-passthrough: "true"
     setDefaultBackend: false
-    pathPrefix: webui
+    pathPrefix: ui
+    pathPrefixAlternate: webui
     rewritePath: true
     hosts: []
       # - host: nuodb-cp-example.local


### PR DESCRIPTION
moving /webui default prefix to /ui while keeping /webui as a fallback. Note that if a user accesses the /webui URL, it will initially retrieve data from /webui and subsequent requests will go to the /ui prefix. The deploy repo will have the legacy UI removed in a separate PR.