### PR TITLE
Fix delayed Toast message

### DIFF
--- a/ui/public/theme/base.css
+++ b/ui/public/theme/base.css
@@ -872,3 +872,24 @@ button:focus {
     font-size: 13px;
     color: white;
 }
+.NuoToast {
+    left: 50%;
+    right: auto;
+    -webkit-transform: translateX(-50%);
+    -moz-transform: translateX(-50%);
+    -ms-transform: translateX(-50%);
+    transform: translateX(-50%);
+    position: absolute;
+}
+
+.NuoToast>div {
+    box-shadow: 0px 3px 5px -1px rgba(0, 0, 0, 0.2), 0px 6px 10px 0px rgba(0, 0, 0, 0.14), 0px 1px 18px 0px rgba(0, 0, 0, 0.12);
+    opacity: 1;
+    transform: none;
+    transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1), transform 150ms cubic-bezier(0.4, 0, 0.2, 1);
+    padding: 8px 15px;
+    border-radius: 5px;
+    background-color: black;
+    color: white;
+    margin: 5px;
+}

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -22,6 +22,7 @@ import { PopupMenu } from './components/controls/Menu';
 import { NUODBAAS_WEBUI_ISRECORDING, Rest } from './components/pages/parts/Rest';
 import OrganizationOverview from './components/pages/OrganizationOverview';
 import { getOrgFromPath } from './utils/schema';
+import Toast from './components/controls/Toast';
 
 /**
  * React Root Application. Sets up dialogs, BrowserRouter and Schema from Control Plane
@@ -84,6 +85,7 @@ export default function App() {
           <CssBaseline />
           <PopupMenu />
           <Dialog />
+          <Toast />
           <Rest isRecording={isRecording} setIsRecording={setIsRecording} />
           <BrowserRouter>
             {isLoggedIn

--- a/ui/src/components/controls/Toast.tsx
+++ b/ui/src/components/controls/Toast.tsx
@@ -1,0 +1,43 @@
+// (C) Copyright 2025 Dassault Systemes SE.  All Rights Reserved.
+
+import React, { Component } from 'react';
+
+let s_instance: Toast | null = null;
+
+interface IProps { }
+
+interface IState {
+    messages?: string[]
+}
+
+export default class Toast extends Component<IProps, IState> {
+    state = {
+        messages: []
+    }
+
+    componentDidMount() {
+        s_instance = this;
+    }
+
+    static show = (msg: string, error: any) => {
+        if (error?.response?.data?.detail) {
+            msg += "\n" + error.response.data.detail;
+        }
+        else {
+            console.log("Toast", msg, error);
+        }
+        s_instance && s_instance.setState({
+            messages: [...s_instance.state.messages, msg]
+        });
+        setTimeout(() => {
+            if (s_instance) {
+                let messages = s_instance.state.messages.slice(1);
+                s_instance.setState({ messages });
+            }
+        }, 5000);
+    }
+
+    render() {
+        return <div className="NuoToast" role="alert">{this.state.messages.map((message: string, index: number) => <div key={index}>{message.split("\n").map((line, idx) => <div key={idx}>{line}</div>)}</div>)}</div>
+    }
+}

--- a/ui/src/components/pages/ListResource.tsx
+++ b/ui/src/components/pages/ListResource.tsx
@@ -12,6 +12,7 @@ import Pagination from "../controls/Pagination";
 import { withTranslation } from "react-i18next";
 import Search, { parseSearch } from "./parts/Search";
 import ResourceHeader from "./parts/ResourceHeader";
+import Toast from "../controls/Toast";
 
 type ItemsAndPathProps = {
     items: [] | null,
@@ -83,7 +84,7 @@ function ListResource(props: PageProps) {
                     })
                 );
             }).catch((reason) => {
-                Rest.toastError("Unable to get resource in " + path, reason);
+                Toast.show("Unable to get resource in " + path, reason);
             });
         }
     }, [page, path, schema, search]);

--- a/ui/src/components/pages/parts/Rest.tsx
+++ b/ui/src/components/pages/parts/Rest.tsx
@@ -2,7 +2,6 @@
 
 import React, { ReactNode } from "react"
 import CircularProgress from '@mui/material/CircularProgress';
-import Snackbar from '@mui/material/Snackbar';
 import axios from "axios";
 import Auth from "../../../utils/auth";
 import { JsonType, RestLogEntry, RestMethodType } from "../../../utils/types";
@@ -11,7 +10,6 @@ let instance: Rest | null = null;
 
 interface State {
     pendingRequests: number,
-    errorMessage?: string | null,
 }
 
 const AUTOMATION_LOG = "nuodbaas-webui-recorded";
@@ -20,7 +18,6 @@ export const NUODBAAS_WEBUI_ISRECORDING = "nuodbaas-webui-isRecording";
 export class Rest extends React.Component<{ isRecording: boolean, setIsRecording: (isRecording: boolean) => void }> {
     state: State = {
         pendingRequests: 0,
-        errorMessage: null,
     }
 
     componentDidMount() {
@@ -30,11 +27,6 @@ export class Rest extends React.Component<{ isRecording: boolean, setIsRecording
     }
 
     lastTimestamp = new Date();
-
-    static toastError(msg: string, error: string) {
-        instance && instance.setState({ errorMessage: msg });
-        console.error(msg, error);
-    }
 
     static incrementPending() {
         if (instance === null) {
@@ -202,13 +194,6 @@ export function RestSpinner() {
     if (!instance) return null;
 
     return <React.Fragment>
-        <Snackbar
-            open={instance.state.errorMessage !== null}
-            autoHideDuration={5000}
-            anchorOrigin={{ vertical: "top", horizontal: "center" }}
-            message={instance.state.errorMessage}
-            onClose={() => instance?.setState({ errorMessage: null })}
-        />
         {instance.state.pendingRequests > 0 ?
             <CircularProgress className="RestSpinner" color="inherit" />
             :

--- a/ui/src/components/pages/parts/Table.tsx
+++ b/ui/src/components/pages/parts/Table.tsx
@@ -14,6 +14,7 @@ import TableSettingsColumns from './TableSettingsColumns';
 import { useEffect, useState } from 'react';
 import CustomDialog from '../custom/CustomDialog';
 import DeleteIcon from '@mui/icons-material/Delete';
+import Toast from '../../controls/Toast';
 
 function getFlattenedKeys(obj: TempAny, prefix?: string): string[] {
     let ret: string[] = [];
@@ -155,7 +156,7 @@ function Table(props: TableProps) {
                 .then(() => {
                     window.location.reload();
                 }).catch((error) => {
-                    Rest.toastError("Unable to delete " + deletePath, error);
+                    Toast.show("Unable to delete " + deletePath, error);
                 });
         }
     }
@@ -178,7 +179,7 @@ function Table(props: TableProps) {
             let promises = await Promise.allSettled(editDeletePaths.map((dPath: any) => Rest.delete(dPath)));
             promises.forEach((result, index) => {
                 if (result.status === "rejected") {
-                    Rest.toastError("Unable to delete " + editDeletePaths[index], result.reason);
+                    Toast.show("Unable to delete " + editDeletePaths[index], result.reason);
                 }
             })
             setSelected(new Set());
@@ -224,7 +225,7 @@ function Table(props: TableProps) {
                 }
                 catch (ex) {
                     const msg = "Error in checking visibility of button.";
-                    Rest.toastError(msg, String(ex));
+                    Toast.show(msg, String(ex));
                     console.error(msg, ex, row);
                 }
 
@@ -244,7 +245,7 @@ function Table(props: TableProps) {
                             if (menu.patch) {
                                 Rest.patch(path + "/" + row["$ref"], menu.patch)
                                     .catch((error) => {
-                                        Rest.toastError("Unable to update " + path + "/" + row["$ref"], error);
+                                        Toast.show("Unable to update " + path + "/" + row["$ref"], error);
                                     })
                             }
                             else if (menu.link) {
@@ -293,7 +294,7 @@ function Table(props: TableProps) {
             }
             catch (ex) {
                 const msg = "Error in custom value evaluation for field \"" + fieldName + "\"";
-                Rest.toastError(msg, String(ex));
+                Toast.show(msg, String(ex));
                 console.error(msg, ex, row);
                 value = ""
             }

--- a/ui/src/utils/schema.ts
+++ b/ui/src/utils/schema.ts
@@ -1,5 +1,6 @@
 // (C) Copyright 2024-2025 Dassault Systemes SE.  All Rights Reserved.
 
+import Toast from "../components/controls/Toast";
 import { Rest } from "../components/pages/parts/Rest";
 import Auth from "./auth"
 import { FieldValuesType, TempAny, SchemaType, FieldParametersType } from "./types";
@@ -390,7 +391,7 @@ export function getResourceEvents(path: string, multiResolve: TempAny, multiReje
                 .catch(reason => multiReject(reason));
         }
         else if(error.status) {
-            Rest.toastError("Cannot retrieve resource for path " + path, error.status + " " + error.message);
+            Toast.show("Cannot retrieve resource for path " + path, error.status + " " + error.message);
         }
         else {
             //request was aborted. Ignore.


### PR DESCRIPTION
The existing Toast message in the `Rest` object didn't properly refresh on changes. Refactored similar to how we show dialogs or popup menu's. Also it now supports multiple toast messages instead of overwriting existing ones if they go in quick succession.