### PR TITLE
Allow to expand shortened text in view

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,7 +108,7 @@ run-integration-tests: build-image setup-integration-tests ## run integration te
 ##@ Development Environment
 
 .PHONY: start-dev
-start-dev: setup-integration-tests ## launch WebUI/ControlPlane/Proxy for development environment
+start-dev: stop-dev setup-integration-tests ## launch WebUI/ControlPlane/Proxy for development environment
 	(cd ui && npm install && npm start &)
 	docker run --rm -d --name nuodb-webui-dev -v `pwd`/docker/development/default.conf:/etc/nginx/conf.d/default.conf --network=host -it nginx:stable-alpine
 
@@ -118,6 +118,10 @@ stop-dev: teardown-integration-tests ## stop development environment processes (
 	if [ "$$PID" != "" ] ; then kill -9 $$PID; fi
 	@PID=$(shell docker ps -aq --filter "name=nuodb-webui-dev"); \
 	if [ "$$PID" != "" ] ; then docker stop $$PID; fi
+	@DOT_KWOK_OWNER=$(shell stat -c '%U' ~/.kwok 2>/dev/null); \
+	if [ "$$DOT_KWOK_OWNER" = "root" ] ; then sudo rm -r ~/.kwok; fi
+	@rm -rf ~/.kwok
+
 
 $(KWOKCTL): $(KUBECTL)
 	mkdir -p bin

--- a/ui/public/theme/base.css
+++ b/ui/public/theme/base.css
@@ -872,3 +872,12 @@ button:focus {
     font-size: 13px;
     color: white;
 }
+.NuoMoreValue {
+    display: inline;
+    color: blue;
+    cursor: pointer;
+}
+
+.NuoMoreValueExpanded {
+    display: inline;
+}

--- a/ui/src/components/fields/FieldBase.tsx
+++ b/ui/src/components/fields/FieldBase.tsx
@@ -150,13 +150,13 @@ export function getRecursiveValue(value: TempAny, t: any) {
     }
 
     let strValue = String(value);
-    let moreValue;
+    let moreValue = "";
     if (strValue.indexOf("\n") !== -1) {
         moreValue = strValue.substring(strValue.indexOf("\n"));
         strValue = strValue.substring(0, strValue.indexOf("\n"));
     }
-    else if (strValue.length > 80) {
-        moreValue = strValue.substring(80);
+    if (strValue.length > 80) {
+        moreValue = strValue.substring(80) + moreValue;
         strValue = strValue.substring(0, 80);
     }
     if (moreValue) {

--- a/ui/src/components/pages/parts/Table.tsx
+++ b/ui/src/components/pages/parts/Table.tsx
@@ -14,6 +14,7 @@ import TableSettingsColumns from './TableSettingsColumns';
 import { useEffect, useState } from 'react';
 import CustomDialog from '../custom/CustomDialog';
 import DeleteIcon from '@mui/icons-material/Delete';
+import { getRecursiveValue } from '../../fields/FieldBase';
 
 function getFlattenedKeys(obj: TempAny, prefix?: string): string[] {
     let ret: string[] = [];
@@ -119,32 +120,6 @@ function Table(props: TableProps) {
             }
         });
         return ret;
-    }
-
-    function showValue(value: TempAny) {
-        if (value === undefined || value === null) {
-            return "";
-        }
-        else if (typeof value === "object") {
-            if (Array.isArray(value)) {
-                return value.map((v, index) => <div key={index}>{showValue(v)}</div>);
-            }
-            else {
-                return <dl className="map">{Object.keys(value).map(key => <div key={key}><dt>{String(key)}</dt><dd>{showValue(value[key])}</dd></div>)}</dl>
-            }
-        }
-        else if (typeof value === "string") {
-            if (value.indexOf("\n") !== -1) {
-                value = value.substring(0, value.indexOf("\n")) + "...";
-            }
-            if (value.length > 80) {
-                value = value.substring(0, 80) + "...";
-            }
-            return String(value);
-        }
-        else {
-            return String(value);
-        }
     }
 
     async function handleDelete(row: TempAny, deletePath: string) {
@@ -289,7 +264,7 @@ function Table(props: TableProps) {
         let value;
         if (cf && cf.value) {
             try {
-                value = showValue(evaluate(row, cf.value));
+                value = getRecursiveValue(evaluate(row, cf.value), t);
             }
             catch (ex) {
                 const msg = "Error in custom value evaluation for field \"" + fieldName + "\"";

--- a/ui/src/resources/translation/en.json
+++ b/ui/src/resources/translation/en.json
@@ -190,7 +190,8 @@
         "viewForResource": "{{resources_one}}",
         "editForResource": "Edit {{resources_one}}",
         "newResource": "New {{resources_one}}",
-        "noData": "No Data"
+        "noData": "No Data",
+        "more": "More"
     },
     "section": {
         "title": {


### PR DESCRIPTION
View values were shortened to 80 characters or until the first newline character to prevent overloading the view with content. This also prevented the user from viewing the entire content.
This PR replaces the "..." with a "More" link which will expand the text when clicked.

Also fixed an issue where "make start-dev" didn't bring up the services if the development machine was killed/stopped without bringing down the services cleanly.