### PR TITLE
avoid window reload() when deleting a resource

### DIFF
--- a/selenium-tests/src/test/java/com/nuodb/selenium/SeleniumTestHelper.java
+++ b/selenium-tests/src/test/java/com/nuodb/selenium/SeleniumTestHelper.java
@@ -2,7 +2,6 @@
 
 package com.nuodb.selenium;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import java.io.File;

--- a/ui/src/components/pages/parts/Table.tsx
+++ b/ui/src/components/pages/parts/Table.tsx
@@ -3,7 +3,7 @@
 import { useNavigate } from 'react-router-dom';
 import { withTranslation } from "react-i18next";
 import { TableBody, TableTh, TableCell, Table as TableCustom, TableHead, TableRow } from '../../controls/Table';
-import { getResourceByPath, getCreatePath, getChild, replaceVariables, getSchemaPath } from "../../../utils/schema";
+import { getResourceByPath, getCreatePath, getChild, replaceVariables, getSchemaPath, hasMonitoredPath } from "../../../utils/schema";
 import FieldFactory from "../../fields/FieldFactory";
 import { Rest } from "./Rest";
 import Dialog from "./Dialog";
@@ -129,7 +129,9 @@ function Table(props: TableProps) {
         if ("yes" === await Dialog.confirm(t("confirm.delete.resource.title", row), t("confirm.delete.resource.body", row), t)) {
             Rest.delete(deletePath)
                 .then(() => {
-                    window.location.reload();
+                    if (!hasMonitoredPath(path)) {
+                        window.location.reload();
+                    }
                 }).catch((error) => {
                     Toast.show("Unable to delete " + deletePath, error);
                 });
@@ -158,6 +160,9 @@ function Table(props: TableProps) {
                 }
             })
             setSelected(new Set());
+            if (!hasMonitoredPath(path)) {
+                window.location.reload();
+            }
         }
     }
 

--- a/ui/src/utils/schema.ts
+++ b/ui/src/utils/schema.ts
@@ -268,6 +268,12 @@ function concatChunks(chunk1: Uint8Array, chunk2: Uint8Array) : Uint8Array {
     return ret;
 }
 
+let monitoredPaths = new Set<string>();
+
+export function hasMonitoredPath(path: string) : boolean {
+    return monitoredPaths.has(path.split("?")[0]);
+}
+
 /**
  * Gets event streaming resource by path (fall back to non-streaming resource on failure)
  * @param {*} path
@@ -281,6 +287,7 @@ export function getResourceEvents(path: string, multiResolve: TempAny, multiReje
 
     Rest.getStream("events" + path, eventsAbortController)
       .then(async (response: TempAny) => {
+        monitoredPaths.add(path.split("?")[0]);
         let event = null;
         let data = null;
         let id = null;
@@ -382,6 +389,7 @@ export function getResourceEvents(path: string, multiResolve: TempAny, multiReje
                 }
             }
         }
+        monitoredPaths.delete(path.split("?")[0]);
       })
       .catch((error) => {
         if(error.status === 404) {
@@ -396,6 +404,7 @@ export function getResourceEvents(path: string, multiResolve: TempAny, multiReje
         else {
             //request was aborted. Ignore.
         }
+        monitoredPaths.delete(path.split("?")[0]);
       });
 
       return eventsAbortController;

--- a/ui/src/utils/schema.ts
+++ b/ui/src/utils/schema.ts
@@ -389,7 +389,6 @@ export function getResourceEvents(path: string, multiResolve: TempAny, multiReje
                 }
             }
         }
-        monitoredPaths.delete(path.split("?")[0]);
       })
       .catch((error) => {
         if(error.status === 404) {
@@ -404,6 +403,8 @@ export function getResourceEvents(path: string, multiResolve: TempAny, multiReje
         else {
             //request was aborted. Ignore.
         }
+      })
+      .finally(()=>{
         monitoredPaths.delete(path.split("?")[0]);
       });
 


### PR DESCRIPTION
The `window.location.reload()` operation is creating the entire website from scratch causing a temporary white screen when interacting with the UI. This is apparent when deleting a user from the view. There is no need for a page reload if the resource has been pulled using event streaming since it will automatically update the content, but we will fall back to a window reload() if event streaming is not active for the specified path. URL options are being ignored since they are not relevant for a content refresh.