### PR TITLE
Lock conflicting typescript npm package minor version

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -22,9 +22,9 @@
     "preval.macro": "^5.0.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-i18next": "^15.0.3",
+    "react-i18next": "~15.4.1",
     "react-router-dom": "^6.23.1",
-    "react-scripts": "5.0.1",
+    "react-scripts": "^5.0.1",
     "stacktrace-js": "^2.0.2",
     "typescript": "^4.9.5",
     "web-vitals": "^2.1.4"


### PR DESCRIPTION
**Changes**

Package react-scripts has typescript@4 as peer dependency which leads to conflicts with react-i18next@15.5.1. Unfortunately no version of react-scripts tolerates typescript@5.

Lock react-i18next to 15.5.x to avoid conflicting versions.

```
npm error code ERESOLVE
npm error ERESOLVE could not resolve
npm error
npm error While resolving: react-scripts@5.0.1
npm error Found: typescript@5.8.3
npm error node_modules/typescript
npm error   typescript@"^5.8.3" from the root project
npm error   peerOptional typescript@"^5" from react-i18next@15.5.1
npm error   node_modules/react-i18next
npm error     react-i18next@"^15.0.3" from the root project
npm error
npm error Could not resolve dependency:
npm error peerOptional typescript@"^3.2.1 || ^4" from react-scripts@5.0.1
npm error node_modules/react-scripts
npm error   react-scripts@"^5.0.1" from the root project
npm error
npm error Conflicting peer dependency: typescript@4.9.5
npm error node_modules/typescript
npm error   peerOptional typescript@"^3.2.1 || ^4" from react-scripts@5.0.1
npm error   node_modules/react-scripts
npm error     react-scripts@"^5.0.1" from the root project
npm error
npm error Fix the upstream dependency conflict, or retry
npm error this command with --force or --legacy-peer-deps
npm error to accept an incorrect (and potentially broken) dependency resolution.
```