### PR TITLE
Display errors and add testing of login providers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,6 +37,7 @@ jobs:
     resource_class: medium
     environment:
       NUODB_CP_REPO: ./nuodb-control-plane
+      NUODB_CP_COMMIT: e98e2b890cda772f07da6bd91991a75868d0f2b6
     steps:
       - checkout
       - aws-cli/setup
@@ -71,6 +72,7 @@ jobs:
           name: "Checkout NuoDB Control Plane repo"
           command: |
             git clone git@github.com:nuodb/nuodb-control-plane.git
+            cd nuodb-control-plane && git checkout "$NUODB_CP_COMMIT"
       - run:
           name: Checking if Docker image exists already
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,8 @@ jobs:
     machine:
       image: ubuntu-2204:2023.10.1
     resource_class: medium
-
+    environment:
+      NUODB_CP_REPO: ./nuodb-control-plane
     steps:
       - checkout
       - aws-cli/setup
@@ -63,6 +64,13 @@ jobs:
           name: Login to Github Container Registry
           command: |
             echo "$GH_TOKEN" | docker login ghcr.io -u "$GH_USER" --password-stdin
+      - add_ssh_keys:
+          fingerprints:
+            - "SHA256:rXyFWvQb0aSIvZXMOSVqlNtRlLK4m81yak/ivRtfBDA"
+      - run:
+          name: "Checkout NuoDB Control Plane repo"
+          command: |
+            git clone git@github.com:nuodb/nuodb-control-plane.git
       - run:
           name: Checking if Docker image exists already
           command: |

--- a/.gitignore
+++ b/.gitignore
@@ -5,8 +5,10 @@ ui/package-lock.json
 ui/build
 selenium-tests/files/kubeconfig
 bin/
+tmp/
 selenium-tests/target
 .project
 .classpath
 build
 docker/development/default.conf
+/.metadata/

--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,4 @@ selenium-tests/target
 .classpath
 build
 docker/development/default.conf
-/.metadata/
+nuodb-control-plane/

--- a/copyright_ignore.txt
+++ b/copyright_ignore.txt
@@ -11,4 +11,5 @@
 \./ui/public/logo192.png$
 \./ui/public/images/
 \./bin/
+\./tmp/
 \./ui\/build\/

--- a/selenium-tests/files/cas-idp.yaml
+++ b/selenium-tests/files/cas-idp.yaml
@@ -1,0 +1,19 @@
+# (C) Copyright 2025 Dassault Systemes SE.  All Rights Reserved.
+
+apiVersion: cp.nuodb.com/v1beta1
+kind: IdentityProvider
+metadata:
+  annotations:
+    description: Central Authentication Service
+  name: cas-idp
+spec:
+  cas:
+    serverUrl: https://127.0.0.1/cas
+  resolveUser:
+    accessRule:
+      value: |
+        {"allow": ["read:ds"]}
+    name:
+      jsonPath: $.user
+    organization:
+      value: ds

--- a/selenium-tests/src/test/java/com/nuodb/selenium/basic/LoginTest.java
+++ b/selenium-tests/src/test/java/com/nuodb/selenium/basic/LoginTest.java
@@ -25,11 +25,39 @@ public class LoginTest extends TestRoutines {
         sendKeys("username", "invalid_user");
         sendKeys("password", "invalid_password");
         click("login_button");
-        assertEquals("Invalid Credentials", waitText("error_message"));
+        assertEquals("Login failed: Bad credentials", waitText("error_message"));
     }
 
     @Test
     public void testLogin() throws MalformedURLException {
         login();
+    }
+
+    @Test
+    public void testIdp() throws MalformedURLException {
+        get("/ui/login");
+        assertEquals("Login with Central Authentication Service", waitText("login_cas-idp"));
+    }
+
+    @Test
+    public void testNonExistentIdp() throws MalformedURLException {
+        get("/ui/login?provider=bogus");
+        assertEquals("Logging in with bogus...", waitText("progress_message"));
+        assertEquals("Login failed: No provider named bogus", waitText("error_message"));
+    }
+
+    @Test
+    public void testInvalidIdpLoginRequest() throws MalformedURLException {
+        get("/ui/login?provider=cas-idp");
+        assertEquals("Logging in with cas-idp...", waitText("progress_message"));
+        assertEquals("Login failed: Query parameter 'ticket' not supplied", waitText("error_message"));
+    }
+
+    @Test
+    public void testUnsuccessfulIdpLogin() throws MalformedURLException {
+        get("/ui/login?provider=cas-idp&ticket=ST-123");
+        assertEquals("Logging in with cas-idp...", waitText("progress_message"));
+        // request should fail with 500 Internal Server Error due to CAS address being unreachable by REST service
+        assertEquals("Login failed: Request failed with status code 500", waitText("error_message"));
     }
 }

--- a/ui/src/components/pages/LoginForm.tsx
+++ b/ui/src/components/pages/LoginForm.tsx
@@ -3,7 +3,7 @@
 import React, { useEffect, useState } from 'react';
 import { useSearchParams, useNavigate } from "react-router-dom";
 import Box from '@mui/material/Box';
-import LinearProgress from '@mui/material/LinearProgress';
+import CircularProgress from '@mui/material/CircularProgress';
 import Auth from "../../utils/auth";
 import Button from '../controls/Button';
 import TextField from '../controls/TextField';
@@ -87,7 +87,12 @@ function LoginForm({ setIsLoggedIn, t }: Props) {
                 ?
                 <center>
                     <Box sx={{ width: 'fit-content' }}>
-                        <LinearProgress variant={error ? "determinate" : "indeterminate"} color="inherit" />
+                        {error
+                        ?
+                        <CircularProgress variant="determinate" color="error" value="100" />
+                        :
+                        <CircularProgress color="inherit" />
+                        }
                         <div data-testid="progress_message">{progressMessage}</div>
                     </Box>
                     {error &&

--- a/ui/src/utils/auth.ts
+++ b/ui/src/utils/auth.ts
@@ -51,10 +51,10 @@ export default class Auth {
                             expiresAtTime: response.data.expiresAtTime,
                             username
                         }));
-                        resolve(true);
+                        resolve(null);
                     }
                 })
-                .catch(() => resolve(false));
+                .catch(resolve);
         });
     }
 


### PR DESCRIPTION
- Display error messages in UI when login via IdP fails. Previously the page appearing before redirect would seem to hang.
- Display a progress indicator before obtaining token and redirecting.
- Configure deploy key to allow the nuodb-control-plane repo to be pulled and the latest development version of the Control Plane code to be tested.
- Make some improvements and fixes to Makefile.