### PR TITLE
fix redirect and IDP deployments in devenv

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -182,7 +182,7 @@ setup-integration-tests: $(KUBECTL) build-image install-crds deploy-cp deploy-op
 		--data-binary \
             '{\"password\":\"passw0rd\", \"name\":\"admin\", \"organization\": \"integrationtest\", \"accessRule\":{\"allow\": \"all:integrationtest\"}}' \
 		-X PUT -H \"Content-Type: application/json\" > /dev/null"
-	$(KUBECTL) apply -f selenium-tests/files/cas-idp.yaml
+	$(KUBECTL) apply -n default -f selenium-tests/files/cas-idp.yaml
 	@docker ps
 	@$(KUBECTL) describe ingress -A
 	@$(KUBECTL) describe pods -A

--- a/selenium-tests/files/nginx-default.conf
+++ b/selenium-tests/files/nginx-default.conf
@@ -2,6 +2,12 @@
 
 server {
   listen 81;
+  absolute_redirect off;
+
+  location / {
+    return 302 /ui/;
+  }
+
   location /ui/ {
     proxy_pass http://localhost:3000/ui/;
   }
@@ -21,10 +27,5 @@ server {
     proxy_buffering off;
     proxy_set_header    Connection  "Upgrade";
     proxy_set_header    Upgrade     $http_upgrade;
-  }
-
-  location / {
-    root /usr/share/nginx/html;
-    index index.html;
   }
 }


### PR DESCRIPTION
fixed issues where the cas-idp configuration was written to the wrong namespace and `/` and `/ui` didn't redirect to `/ui/`