### PR TITLE
lazy load SQL tables in combo box

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,7 +109,7 @@ deploy-cp: build-cp $(HELM) $(KIND)
 .PHONY: undeploy-cp
 undeploy-cp: $(KIND) $(HELM)
 	@if [ "`$(KIND) get clusters`" = "kind" ] ; then \
-		@$(HELM) uninstall --ignore-not-found -n default nuodb-cp || true; \
+		$(HELM) uninstall --ignore-not-found -n default nuodb-cp || true; \
 	fi
 
 .PHONY: deploy-operator

--- a/ui/public/theme/base.css
+++ b/ui/public/theme/base.css
@@ -638,7 +638,7 @@ code {
     color: rgba(200, 200, 200, 1);
 
 }
-.NuoOrgSelector {
+.NuoComboBox {
     display: flex;
     color: #cdd1d6;
     flex-direction: row;
@@ -650,14 +650,14 @@ code {
         overflow: hidden;
 }
 
-.NuoOrgSelector>div {
+.NuoComboBox>div {
     display: flex;
     flex-direction: row;
     align-items: center;
     text-wrap: nowrap;
 }
 
-.NuoOrgSelector>div>svg {
+.NuoComboBox>div>svg {
     margin: 5px 10px 5px 0px;
         color: #cdd1d6;
         border: 1px solid;
@@ -667,8 +667,8 @@ code {
         height: 30px;
 }
 
-.NuoLeftMenuCollapsed>.NuoOrgSelector,
-.NuoLeftMenuCollapsed *>.NuoOrgSelector {
+.NuoLeftMenuCollapsed>.NuoComboBox,
+.NuoLeftMenuCollapsed *>.NuoComboBox {
     padding: 0 5px;
     justify-content: left;
 }

--- a/ui/src/components/controls/ComboBox.tsx
+++ b/ui/src/components/controls/ComboBox.tsx
@@ -5,7 +5,7 @@ import UnfoldMoreIcon from '@mui/icons-material/UnfoldMore';
 import MoreVertIcon from '@mui/icons-material/MoreVert';
 
 type ComboBoxProps = {
-    loadItems: () => Promise<MenuItemProps[]>;
+    loadItems: (useCache: boolean) => Promise<MenuItemProps[]>;
     children: ReactNode;
     selected?: string;
     align?: "left" | "right"; //defaults to "left"
@@ -109,7 +109,7 @@ export default function ComboBox({ loadItems, children, selected, align }: Combo
 
     useEffect(() => {
         window.addEventListener("scroll", handleScroll);
-        loadItems().then(items => setItems(items));
+        loadItems(true).then(items => setItems(items));
         return () => {
             window.removeEventListener('scroll', handleScroll);
         };
@@ -147,7 +147,7 @@ export default function ComboBox({ loadItems, children, selected, align }: Combo
 
     function showPopup(event: React.MouseEvent<HTMLDivElement, MouseEvent> | React.KeyboardEvent<HTMLDivElement>) {
         event.stopPropagation();
-        loadItems().then(items => {
+        loadItems(false).then(items => {
             setItems(items);
         });
         const rect = event.currentTarget.getBoundingClientRect();

--- a/ui/src/components/controls/Tabs.tsx
+++ b/ui/src/components/controls/Tabs.tsx
@@ -24,7 +24,7 @@ function badge(count: number) {
 }
 
 export function Tabs({ children, currentTab, setCurrentTab, badges }: TabsProps) {
-    children = children.filter(child => child.props.id && child.props.label && child.props.children);
+    children = children.filter(child => child.props.id && child.props.label);
 
     return <div className="NuoTabs">
         <ul>{children.map((child, index) => (

--- a/ui/src/components/pages/SqlPage.tsx
+++ b/ui/src/components/pages/SqlPage.tsx
@@ -5,7 +5,6 @@ import { useParams } from "react-router"
 import { MenuItemProps, PageProps } from "../../utils/types";
 import PageLayout from "./parts/PageLayout";
 import { withTranslation } from "react-i18next";
-import Select, { SelectOption } from '../controls/Select';
 import Typography from '@mui/material/Typography';
 import Breadcrumbs from '@mui/material/Breadcrumbs';
 import { styled } from '@mui/material';
@@ -18,11 +17,32 @@ import SqlQueryTab from './sql/SqlQueryTab';
 import { SqlType } from '../../utils/SqlSocket';
 import ComboBox from '../controls/ComboBox';
 
+type SqlTabsProps = {
+    dbTable: string;
+    sqlConnection: SqlType | undefined;
+};
+
+function SqlTabs({ dbTable, sqlConnection }: SqlTabsProps) {
+    const [tabIndex, setTabIndex] = useState<number>(0);
+
+    if (!sqlConnection) {
+        return null;
+    }
+
+    let tabs = [];
+    if (dbTable) {
+        tabs.push(<Tab id="browse" label={t("form.sqleditor.label.tab.browse")}>{tabIndex === tabs.length && <SqlBrowseTab sqlConnection={sqlConnection} table={dbTable} />}</Tab>);
+    }
+    tabs.push(<Tab id="query" label={t("form.sqleditor.label.tab.query")}>{tabIndex === tabs.length && <SqlQueryTab sqlConnection={sqlConnection} dbTable={dbTable} />}</Tab>);
+    return <Tabs currentTab={tabIndex} setCurrentTab={(tabIndex) => setTabIndex(tabIndex)}>{tabs}</Tabs>
+}
+
+let tablesCache: string[] | undefined = undefined;
+
 function SqlPage(props: PageProps) {
     const params = useParams();
     const [dbTable, setDbTable] = useState("");
     const [sqlConnection, setSqlConnection] = useState<SqlType | undefined | void | "">(undefined);
-    const [tabIndex, setTabIndex] = useState<number>(0);
 
     const StyledBreadcrumbs = styled(Breadcrumbs)({
         '.MuiBreadcrumbs-ol': {
@@ -30,40 +50,30 @@ function SqlPage(props: PageProps) {
         }
     });
 
-    async function loadTables(): Promise<MenuItemProps[]> {
+    async function loadTables(useCache: boolean): Promise<MenuItemProps[]> {
         if (!sqlConnection) {
             return new Promise((resolve) => resolve([]));
         }
-        let tables: string[] = [];
-        const results = await sqlConnection.runCommand("EXECUTE_QUERY", ["SELECT tablename FROM system.tables where type = 'TABLE' and schema = '" + sqlConnection.getDefaultSchema() + "'"]);
-        if (results.error) {
-            Toast.show(results.error, results);
-            setDbTable("");
-        }
-        else if (results.rows) {
-            tables = results.rows.map(row => row.values[0]);
-        }
-        if (!tables.includes(dbTable)) {
-            if (tables.length > 0) {
-                setDbTable(tables[0]);
-            }
-            else {
+        if (!useCache || !tablesCache) {
+            tablesCache = [];
+            const results = await sqlConnection.runCommand("EXECUTE_QUERY", ["SELECT tablename FROM system.tables where type = 'TABLE' and schema = '" + sqlConnection.getDefaultSchema() + "'"]);
+            if (results.error) {
+                Toast.show(results.error, results);
                 setDbTable("");
             }
+            else if (results.rows) {
+                tablesCache = results.rows.map(row => row.values[0]);
+                if (!tablesCache.includes(dbTable)) {
+                    if (tablesCache.length > 0) {
+                        setDbTable(tablesCache[0]);
+                    }
+                    else {
+                        setDbTable("");
+                    }
+                }
+            }
         }
-        return new Promise((resolve) => resolve(tables.map(table => { return { id: table, label: table, onClick: () => { setDbTable(table) } } })));
-    }
-
-    function renderTabs(dbTable: string) {
-        if (!sqlConnection) {
-            return null;
-        }
-        let tabs = [];
-        if (dbTable) {
-            tabs.push(<Tab id="browse" label={t("form.sqleditor.label.tab.browse")}><SqlBrowseTab sqlConnection={sqlConnection} table={dbTable} /></Tab>);
-        }
-        tabs.push(<Tab id="query" label={t("form.sqleditor.label.tab.query")}><SqlQueryTab sqlConnection={sqlConnection} dbTable={dbTable} /></Tab>);
-        return <Tabs currentTab={tabIndex} setCurrentTab={(tabIndex) => setTabIndex(tabIndex)}>{tabs}</Tabs>
+        return new Promise((resolve) => resolve((tablesCache || []).map(table => { return { id: table, label: table, onClick: () => { setDbTable(table) } } })));
     }
 
     return <PageLayout {...props}>
@@ -81,7 +91,7 @@ function SqlPage(props: PageProps) {
                 </StyledBreadcrumbs>
             </div>
         </div>
-        {sqlConnection ? renderTabs(dbTable) : <SqlLogin setSqlConnection={(conn: SqlType) => {
+        {sqlConnection ? <SqlTabs dbTable={dbTable} sqlConnection={sqlConnection} /> : <SqlLogin setSqlConnection={(conn: SqlType) => {
             setSqlConnection(conn);
         }} />}
     </PageLayout>;

--- a/ui/src/components/pages/parts/LeftMenu.tsx
+++ b/ui/src/components/pages/parts/LeftMenu.tsx
@@ -50,7 +50,7 @@ function Organization({ schema, org, orgs, setOrg, onSelection, t }: Organizatio
                 }
             }
         })];
-    return <ComboBox className="NuoOrgSelector" items={orgMenuItems} selected={org}>
+    return <ComboBox loadItems={() => { return new Promise((resolve) => resolve(orgMenuItems)) }} selected={org}>
         <CorporateFareIcon /><label>{org === "" ? t("field.select.allOrgs") : org}</label>
     </ComboBox>;
 }

--- a/ui/src/components/pages/sql/SqlQueryTab.tsx
+++ b/ui/src/components/pages/sql/SqlQueryTab.tsx
@@ -19,7 +19,12 @@ function SqlQueryTab({ sqlConnection, dbTable }: SqlQueryTabProps) {
     const [executing, setExecuting] = useState(false);
 
     useEffect(()=>{
-        setSqlQuery("select * from `" + dbTable + "` limit 100");
+        if (dbTable) {
+            setSqlQuery("SELECT * FROM `" + dbTable + "` LIMIT 100");
+        }
+        else {
+            setSqlQuery("CREATE TABLE `table1` (`name` VARCHAR(80))");
+        }
         setResults(undefined);
     }, [dbTable]);
 

--- a/ui/src/components/pages/sql/SqlResultsRender.tsx
+++ b/ui/src/components/pages/sql/SqlResultsRender.tsx
@@ -12,7 +12,7 @@ import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 type SqlTableProps = {
     results?: SqlResponse;
     isFiltered?: boolean;
-    setShowFilterDialog: (showFilterDialog: boolean) => void;
+    setShowFilterDialog?: (showFilterDialog: boolean) => void;
     orderBy?: string;
     setOrderBy?: (orderBy: string) => void;
     isAscending?: boolean;
@@ -56,7 +56,7 @@ function SqlResultsRender({ results, setShowFilterDialog, orderBy, setOrderBy, i
                     </div>
                 </TableTh>)}
                 {isFiltered !== undefined && <TableTh className="NuoTableMenuCell">
-                    <div className={isFiltered ? "NuoFilterActive" : "NuoFilterInactive"} onClick={() => setShowFilterDialog(true)}>
+                    <div className={isFiltered ? "NuoFilterActive" : "NuoFilterInactive"} onClick={() => setShowFilterDialog && setShowFilterDialog(true)}>
                         <FilterListIcon />
                     </div>
                 </TableTh>}


### PR DESCRIPTION
The SQL editor has a combo box where the user can select from the available tables to be shown in the browser tab or pre-populate the Query tab. If the user creates/deletes a table, this combo box was not updated. With this PR we are lazy loading the tables. Note that the current table (even if deleted) will not be updated for performance reasons, but as soon as the user opens the combo box, the new table state is reflected in the list.

Also keyboard-enabled the combo box and menu component.