### PR TITLE
show descriptions for enum values

### DIFF
--- a/.devenv.config
+++ b/.devenv.config
@@ -1,3 +1,3 @@
-# (C) Copyright 2024-2025 Dassault Systemes SE.  All Rights Reserved.
+# (C) Copyright 2025 Dassault Systemes SE.  All Rights Reserved.
 REPO_DEPENDENCY=git@github.com:nuodb/nuodbaas-sql
 REPO_DEPENDENCY=git@github.com:nuodb/nuodb-control-plane

--- a/.devenv.config
+++ b/.devenv.config
@@ -1,0 +1,2 @@
+REPO_DEPENDENCY=git@github.com:nuodb/nuodbaas-sql
+REPO_DEPENDENCY=git@github.com:nuodb/nuodb-control-plane

--- a/.devenv.config
+++ b/.devenv.config
@@ -1,2 +1,3 @@
+# (C) Copyright 2024-2025 Dassault Systemes SE.  All Rights Reserved.
 REPO_DEPENDENCY=git@github.com:nuodb/nuodbaas-sql
 REPO_DEPENDENCY=git@github.com:nuodb/nuodb-control-plane

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ BIN_DIR ?= $(PROJECT_DIR)/bin
 export PATH := $(BIN_DIR):$(PATH)
 
 OS := $(shell uname -s | tr '[:upper:]' '[:lower:]')
-ARCH := $(shell uname -m | sed "s/x86_64/amd64/g")
+ARCH := $(shell uname -m | sed "s/x86_64/amd64/g" | sed "s/aarch64/arm64/g")
 
 KIND_VERSION ?= 0.27.0
 KUBECTL_VERSION ?= 1.28.3

--- a/selenium-tests/src/test/java/com/nuodb/selenium/SeleniumTestHelper.java
+++ b/selenium-tests/src/test/java/com/nuodb/selenium/SeleniumTestHelper.java
@@ -168,7 +168,8 @@ public class SeleniumTestHelper {
             boolean found = false;
             for(WebElement liElement : liElements) {
                 String text = liElement.getText();
-                if(value.equals(text) || text.startsWith(value + " ")) {
+                List<WebElement> webTitles = liElement.findElements(By.className("NuoEnumItemTitle"));
+                if(value.equals(text) || webTitles.size() > 0 && value.equals(webTitles.get(0).getText())) {
                     liElement.click();
                     found = true;
                     break;

--- a/selenium-tests/src/test/java/com/nuodb/selenium/SeleniumTestHelper.java
+++ b/selenium-tests/src/test/java/com/nuodb/selenium/SeleniumTestHelper.java
@@ -167,7 +167,8 @@ public class SeleniumTestHelper {
             List<WebElement> liElements = element.findElements(By.tagName("li"));
             boolean found = false;
             for(WebElement liElement : liElements) {
-                if(value.equals(liElement.getText())) {
+                String text = liElement.getText();
+                if(value.equals(text) || text.startsWith(value + " ")) {
                     liElement.click();
                     found = true;
                     break;

--- a/ui/public/theme/base.css
+++ b/ui/public/theme/base.css
@@ -939,4 +939,5 @@ button:focus {
     display: inline;
     color: lightgray;
     text-wrap: wrap;
+    font-size: 0.9em;
 }

--- a/ui/public/theme/base.css
+++ b/ui/public/theme/base.css
@@ -926,3 +926,17 @@ button:focus {
     color: white;
     border-radius: 5px;
 }
+.NuoEnumItem {
+    display: inline;
+}
+
+.NuoEnumItemTitle {
+    display: inline;
+    padding: 0 10px 0 0;
+}
+
+.NuoEnumItemDescription {
+    display: inline;
+    color: lightgray;
+    text-wrap: wrap;
+}

--- a/ui/src/components/fields/FieldSelect.tsx
+++ b/ui/src/components/fields/FieldSelect.tsx
@@ -26,7 +26,12 @@ export default function FieldSelect(props: FieldProps): FieldBaseType {
                 if (enumDescriptions) {
                     description = enumDescriptions[e]
                 }
-                return <SelectOption value={e}>{t("field.enum." + prefix + "." + e, e)} {description}</SelectOption>
+                return <SelectOption value={e}>
+                    <div className="NuoEnumItem">
+                        <div className="NuoEnumItemTitle">{t("field.enum." + prefix + "." + e, e)}</div>
+                        {description && <div className="NuoEnumItemDescription">{description}</div>}
+                    </div>
+                </SelectOption>
             })}
         </Select>;
     }

--- a/ui/src/components/fields/FieldSelect.tsx
+++ b/ui/src/components/fields/FieldSelect.tsx
@@ -20,7 +20,14 @@ export default function FieldSelect(props: FieldProps): FieldBaseType {
             setValues(v);
         }} onBlur={() => FieldBase(props).validate()} disabled={readonly}>
             <SelectOption value="">{t("field.select.selectItem")}</SelectOption>
-            {parameter && parameter.enum && parameter.enum.map(e => <SelectOption key={e} value={e}>{t("field.enum." + prefix + "." + e, e)}</SelectOption>)}
+            {parameter && parameter.enum && parameter.enum.map(e => {
+                let description = undefined;
+                const enumDescriptions = parameter["x-enum-descriptions"];
+                if (enumDescriptions) {
+                    description = enumDescriptions[e]
+                }
+                return <SelectOption value={e}>{t("field.enum." + prefix + "." + e, e)} {description}</SelectOption>
+            })}
         </Select>;
     }
 

--- a/ui/src/utils/types.ts
+++ b/ui/src/utils/types.ts
@@ -17,6 +17,7 @@ export type FieldParameterType = {
     required?: boolean,
     pattern?: string,
     "x-tf-sensitive"?: boolean,
+    "x-enum-descriptions"?: {[key:string]:string},
     expand?: boolean,
     in?: string,
     items?: FieldParameterType,


### PR DESCRIPTION
This presents descriptions of the enum values (i.e. resource allocations for particular tiers). Previously, a user wouldn't know what "n0.nano" actually means - with the descriptions showing in the UI they know what resources are allocated for a database or project.