### PR TITLE
Update IdentityProvider to use correct field

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ jobs:
   build_image:
     executor: ubuntu_vm
     environment:
-      NUODB_CP_COMMIT: e98e2b890cda772f07da6bd91991a75868d0f2b6
+      NUODB_CP_COMMIT: d84cb0d9f4116ef6391cfd7533712f22f8e62a2e
     steps:
       - checkout
       - add_ssh_keys:

--- a/selenium-tests/files/cas-idp.yaml
+++ b/selenium-tests/files/cas-idp.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   cas:
     serverUrl: https://127.0.0.1/cas
-  resolveUser:
+  provisionUser:
     accessRule:
       value: |
         {"allow": ["read:ds"]}


### PR DESCRIPTION
The `spec.resolveUser` field has been changed to `spec.provisionUser` in the NuoDB Control Plane, so the checked in IdentityProvider has to be updated.