### PR TITLE
SQL Editor: Fix formatting of "show tables"

### DIFF
--- a/ui/src/components/pages/sql/SqlResultsRender.tsx
+++ b/ui/src/components/pages/sql/SqlResultsRender.tsx
@@ -43,7 +43,7 @@ function SqlResultsRender({ results, setShowFilterDialog, orderBy, setOrderBy, i
             <TableRow>
                 {results.columns?.map((column, index: number) => <TableTh key={index}>
                     <div className="NuoRow">
-                        {column.name}
+                        {column.label || column.name}
                         {orderBy !== undefined && <div onClick={() => sort(column.name)}>
                             {orderBy === column.name ?
                                 (isAscending ?
@@ -64,7 +64,11 @@ function SqlResultsRender({ results, setShowFilterDialog, orderBy, setOrderBy, i
         </TableHead>
         <TableBody>
             {results.rows?.map((row, index) => <TableRow key={index}>
-                {row.values.map((col, cindex) => <TableCell key={cindex}>{String(col)}</TableCell>)}
+                {row.values.map((col, cindex) => <TableCell key={cindex}>
+                    <div style={{ whiteSpace: "pre" }}>
+                        {String(col).trim()}
+                    </div>
+                </TableCell>)}
                 {isFiltered !== undefined && <TableCell>&nbsp;</TableCell>}
             </TableRow>)}
         </TableBody>

--- a/ui/src/utils/SqlSocket.ts
+++ b/ui/src/utils/SqlSocket.ts
@@ -26,6 +26,7 @@ export type SqlRequest = {
 
 export type ColumnMetaData = {
     name: string;
+    label?: string;
     type: string;
 }
 
@@ -55,7 +56,7 @@ export default function SqlSocket(organization: string, project: string, databas
         let request : SqlRequest = {operation: operation.toString(), args, requestId: String(nextTransactionId)};
         nextTransactionId++;
         const response = await axios.post(
-            "/api/sql/" + encodeURIComponent(organization) + "/" + encodeURIComponent(project) + "/" + encodeURIComponent(database) + "/" + encodeURIComponent(schema),
+            "/api/sql/query/" + encodeURIComponent(organization) + "/" + encodeURIComponent(project) + "/" + encodeURIComponent(database) + "/" + encodeURIComponent(schema),
             request,
             { headers:{
                 "Authorization": "Basic " + btoa(dbUsername + ":" + dbPassword)


### PR DESCRIPTION
the `show tables` command returns a result with newline characters and white spaces. The browser automatically re-formats those to single spaces resulting in a one-line output. Added `pre` styling to preserve the newlines and spaces (while removing the whitespace at the beginning and end for cleaner output).
Some additional changes:
- fixed column header names if an `alias` is used in the select statements.
- changed to new "/api/sql/query/" URL to match with latest nuodbaas-sql service changes.
