### PR TITLE
add SQL import feature

### DIFF
--- a/docker/development/default.conf.template
+++ b/docker/development/default.conf.template
@@ -20,6 +20,8 @@ server {
 
   location /api/sql/ {
     proxy_pass %%%NUODB_SQL_URL_BASE%%%/sql/;
+    proxy_buffering off;
+    client_max_body_size 1024g;
   }
 
   location /api/ws/sql/ {

--- a/selenium-tests/files/nginx-default.conf
+++ b/selenium-tests/files/nginx-default.conf
@@ -20,6 +20,7 @@ server {
   location /api/sql/ {
     proxy_pass http://localhost/api/sql/;
     proxy_buffering off;
+    client_max_body_size 1024g;
   }
 
   location /api/ws/sql/ {

--- a/ui/public/theme/base.css
+++ b/ui/public/theme/base.css
@@ -797,7 +797,8 @@ code {
     background-color: lightgray;
     cursor: pointer;
 }
-button {
+button,
+#NuoButton {
     display: flex;
     flex: 1 1 auto;
     align-items: center;
@@ -980,8 +981,17 @@ label.NuoUpload > div {
     display: flex;
     align-items: center;
     justify-content: center;
+    text-align: center;
 }
 
 label.NuoUpload:hover {
     background-color: rgb(200, 200, 200);
+}
+.NuoBackgroundTasksStatus {
+    position: absolute;
+    bottom: 0;
+    right: 0;
+    z-index: 500;
+    box-shadow: 0px 5px 5px -3px rgba(0, 0, 0, 0.2), 0px 8px 10px 1px rgba(0, 0, 0, 0.14), 0px 3px 14px 2px rgba(0, 0, 0, 0.12);
+    padding: 5px;
 }

--- a/ui/public/theme/base.css
+++ b/ui/public/theme/base.css
@@ -987,6 +987,10 @@ label.NuoUpload > div {
 label.NuoUpload:hover {
     background-color: rgb(200, 200, 200);
 }
+.NuoUploadLightLabel {
+    color: lightgray;
+    font-size: .8em;
+}
 .NuoBackgroundTasksStatus {
     position: absolute;
     bottom: 0;

--- a/ui/public/theme/base.css
+++ b/ui/public/theme/base.css
@@ -999,18 +999,3 @@ label.NuoUpload:hover {
     box-shadow: 0px 5px 5px -3px rgba(0, 0, 0, 0.2), 0px 8px 10px 1px rgba(0, 0, 0, 0.14), 0px 3px 14px 2px rgba(0, 0, 0, 0.12);
     padding: 5px;
 }
-.NuoBackgroundTasksStatusOverlay {
-    /* position: absolute; */
-    background-color: rgba(0, 0, 0, .5);
-    color: white;
-    z-index: 101;
-    display: flex;
-    flex: 1 1 auto;
-    padding: 5px;
-    /* opacity: 0; */
-    cursor: default;
-}
-
-.NuoBackgroundTasksStatusOverlay:hover {
-    opacity: 1;
-}

--- a/ui/public/theme/base.css
+++ b/ui/public/theme/base.css
@@ -999,3 +999,18 @@ label.NuoUpload:hover {
     box-shadow: 0px 5px 5px -3px rgba(0, 0, 0, 0.2), 0px 8px 10px 1px rgba(0, 0, 0, 0.14), 0px 3px 14px 2px rgba(0, 0, 0, 0.12);
     padding: 5px;
 }
+.NuoBackgroundTasksStatusOverlay {
+    /* position: absolute; */
+    background-color: rgba(0, 0, 0, .5);
+    color: white;
+    z-index: 101;
+    display: flex;
+    flex: 1 1 auto;
+    padding: 5px;
+    /* opacity: 0; */
+    cursor: default;
+}
+
+.NuoBackgroundTasksStatusOverlay:hover {
+    opacity: 1;
+}

--- a/ui/public/theme/base.css
+++ b/ui/public/theme/base.css
@@ -229,6 +229,13 @@ html {
     flex-direction: column;
     flex: 0 0 auto;
 }
+
+.NuoCenter {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
 .NuoTableSettingsItem>label {
     display: flex;
     flex: 1 1 auto;
@@ -949,4 +956,32 @@ button:focus {
 
 .NuoLoginForm .MuiFormControl-root + .MuiFormControl-root {
   margin-top: 1rem;
+}
+
+input[type="file"].NuoUpload {
+    display: none;
+}
+
+label.NuoUpload {
+    width: 100px;
+    height: 100px;
+    border-radius: 50px;
+    background-color: inherit;
+    border-style: dotted;
+    border-color: lightgray;
+    color: lightgray;
+    border-width: 3px;
+    align-items: center;
+    justify-content: center;
+    display: flex;
+}
+
+label.NuoUpload > div {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+label.NuoUpload:hover {
+    background-color: rgb(200, 200, 200);
 }

--- a/ui/public/theme/base.json
+++ b/ui/public/theme/base.json
@@ -10,7 +10,7 @@
                 "tier",
                 "properties",
                 "state",
-                "*"
+                "status"
             ],
             "fields": {
                 "state": {

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -24,6 +24,7 @@ import { NUODBAAS_WEBUI_ISRECORDING, Rest } from './components/pages/parts/Rest'
 import OrganizationOverview from './components/pages/OrganizationOverview';
 import { getOrgFromPath } from './utils/schema';
 import Toast from './components/controls/Toast';
+import { BackgroundTasks } from './utils/BackgroundTasks';
 
 /**
  * React Root Application. Sets up dialogs, BrowserRouter and Schema from Control Plane
@@ -82,6 +83,7 @@ export default function App() {
   return (
     <div className="App" data-testid={orgs.length > 0 ? "banner-done" : ""}>
       <GlobalErrorBoundary>
+        <BackgroundTasks value={[]}>
         <Customizations>
           <CssBaseline />
           <PopupMenu />
@@ -117,6 +119,7 @@ export default function App() {
             }
           </BrowserRouter>
         </Customizations>
+        </BackgroundTasks>
       </GlobalErrorBoundary>
     </div>
   );

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -36,7 +36,10 @@ export default function App() {
   const [isRecording, setIsRecording] = useState(sessionStorage.getItem(NUODBAAS_WEBUI_ISRECORDING) === "true");
   const [org, setOrg] = useState("");
   const [orgs, setOrgs] = useState<string[]>([]);
-  const pageProps = { schema, isRecording, org, setOrg, orgs };
+  const [tasks, setTasks] = useState<BackgroundTaskType[]>([]);
+  const pageProps = {
+    schema, isRecording, org, setOrg, orgs, tasks, setTasks: setTasks
+  };
 
   useEffect(() => {
     if (!isLoggedIn) {
@@ -83,7 +86,7 @@ export default function App() {
   return (
     <div className="App" data-testid={orgs.length > 0 ? "banner-done" : ""}>
       <GlobalErrorBoundary>
-        <BackgroundTasks />
+        <BackgroundTasks tasks={tasks} setTasks={setTasks} />
         <Customizations>
           <CssBaseline />
           <PopupMenu />

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -24,7 +24,7 @@ import { NUODBAAS_WEBUI_ISRECORDING, Rest } from './components/pages/parts/Rest'
 import OrganizationOverview from './components/pages/OrganizationOverview';
 import { getOrgFromPath } from './utils/schema';
 import Toast from './components/controls/Toast';
-import { BackgroundTasks } from './utils/BackgroundTasks';
+import BackgroundTasks, { BackgroundTaskType } from './utils/BackgroundTasks';
 
 /**
  * React Root Application. Sets up dialogs, BrowserRouter and Schema from Control Plane
@@ -83,7 +83,7 @@ export default function App() {
   return (
     <div className="App" data-testid={orgs.length > 0 ? "banner-done" : ""}>
       <GlobalErrorBoundary>
-        <BackgroundTasks value={[]}>
+        <BackgroundTasks />
         <Customizations>
           <CssBaseline />
           <PopupMenu />
@@ -119,7 +119,6 @@ export default function App() {
             }
           </BrowserRouter>
         </Customizations>
-        </BackgroundTasks>
       </GlobalErrorBoundary>
     </div>
   );

--- a/ui/src/components/controls/Button.tsx
+++ b/ui/src/components/controls/Button.tsx
@@ -1,6 +1,6 @@
 // (C) Copyright 2024-2025 Dassault Systemes SE.  All Rights Reserved.
 
-import React, { ReactNode } from 'react';
+import React, { JSX, ReactNode } from 'react';
 
 export type ButtonProps = {
     "data-testid"?: string,

--- a/ui/src/components/controls/CircularProgressWithLabel.tsx
+++ b/ui/src/components/controls/CircularProgressWithLabel.tsx
@@ -1,0 +1,33 @@
+// (C) Copyright 2025 Dassault Systemes SE.  All Rights Reserved.
+
+import CircularProgress, { CircularProgressProps } from '@mui/material/CircularProgress';
+import Typography from '@mui/material/Typography';
+import Box from '@mui/material/Box';
+
+export default function CircularProgressWithLabel(
+props: CircularProgressProps & { value: number },
+) {
+return (
+    <Box sx={{ position: 'relative', display: 'inline-flex' }}>
+    <CircularProgress variant="determinate" {...props} />
+    <Box
+        sx={{
+        top: 0,
+        left: 0,
+        bottom: 0,
+        right: 0,
+        position: 'absolute',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        }}
+    >
+        <Typography
+        variant="caption"
+        component="div"
+        sx={{ color: 'text.secondary' }}
+        >{`${Math.round(props.value)}%`}</Typography>
+    </Box>
+    </Box>
+);
+}

--- a/ui/src/components/controls/ComboBox.tsx
+++ b/ui/src/components/controls/ComboBox.tsx
@@ -154,9 +154,9 @@ export default function ComboBox({ loadItems, children, selected, align }: Combo
         setPosition({ scrollX: window.scrollX, scrollY: window.scrollY, x: rect.x, y: rect.y, width: rect.width, height: rect.height });
     }
 
-    return <>{renderDropdown()}<div className="NuoComboBox" tabIndex={0} onClick={showPopup} onKeyDown={(event) => {
+    return <div>{renderDropdown()}<div className="NuoComboBox" tabIndex={0} onClick={showPopup} onKeyDown={(event) => {
         if (event.key === "Enter" || event.key === "ArrowDown") {
             showPopup(event);
         }
-    }}><div>{children}</div><UnfoldMoreIcon /></div></>
+    }}><div>{children}</div><UnfoldMoreIcon /></div></div>
 }

--- a/ui/src/components/controls/TextField.tsx
+++ b/ui/src/components/controls/TextField.tsx
@@ -1,6 +1,6 @@
 // (C) Copyright 2024-2025 Dassault Systemes SE.  All Rights Reserved.
 
-import React from 'react';
+import React, { JSX } from 'react';
 import { isMaterial } from '../../utils/Customizations';
 import { IconButton, InputAdornment, TextField as MuiTextField } from '@mui/material';
 import InfoPopup from './InfoPopup';
@@ -12,7 +12,7 @@ export type TextFieldProps = {
     id: string,
     label: string,
     description?: string,
-    type?: "password" | "datetime-local" | "text",
+    type?: "password" | "datetime-local" | "text" | "file",
     value?: string,
     defaultValue?: string,
     autoFocus?: boolean,

--- a/ui/src/components/pages/SqlPage.tsx
+++ b/ui/src/components/pages/SqlPage.tsx
@@ -16,6 +16,7 @@ import Toast from '../controls/Toast';
 import SqlQueryTab from './sql/SqlQueryTab';
 import { SqlType } from '../../utils/SqlSocket';
 import ComboBox from '../controls/ComboBox';
+import SqlImportTab from './sql/SqlImportTab';
 
 type SqlTabsProps = {
     dbTable: string;
@@ -34,6 +35,7 @@ function SqlTabs({ dbTable, sqlConnection }: SqlTabsProps) {
         tabs.push(<Tab id="browse" label={t("form.sqleditor.label.tab.browse")}>{tabIndex === tabs.length && <SqlBrowseTab sqlConnection={sqlConnection} table={dbTable} />}</Tab>);
     }
     tabs.push(<Tab id="query" label={t("form.sqleditor.label.tab.query")}>{tabIndex === tabs.length && <SqlQueryTab sqlConnection={sqlConnection} dbTable={dbTable} />}</Tab>);
+    tabs.push(<Tab id="import" label={t("form.sqleditor.label.tab.import")}>{tabIndex === tabs.length && <SqlImportTab sqlConnection={sqlConnection} dbTable={dbTable} />}</Tab>);
     return <Tabs currentTab={tabIndex} setCurrentTab={(tabIndex) => setTabIndex(tabIndex)}>{tabs}</Tabs>
 }
 

--- a/ui/src/components/pages/SqlPage.tsx
+++ b/ui/src/components/pages/SqlPage.tsx
@@ -17,13 +17,16 @@ import SqlQueryTab from './sql/SqlQueryTab';
 import { SqlType } from '../../utils/SqlSocket';
 import ComboBox from '../controls/ComboBox';
 import SqlImportTab from './sql/SqlImportTab';
+import { BackgroundTaskType } from '../../utils/BackgroundTasks';
 
-type SqlTabsProps = {
+interface SqlTabsProps {
+    tasks: BackgroundTaskType[];
+    setTasks: React.Dispatch<React.SetStateAction<BackgroundTaskType[]>>;
     dbTable: string;
     sqlConnection: SqlType | undefined;
 };
 
-function SqlTabs({ dbTable, sqlConnection }: SqlTabsProps) {
+function SqlTabs({ dbTable, sqlConnection, tasks, setTasks }: SqlTabsProps) {
     const [tabIndex, setTabIndex] = useState<number>(0);
 
     if (!sqlConnection) {
@@ -35,7 +38,7 @@ function SqlTabs({ dbTable, sqlConnection }: SqlTabsProps) {
         tabs.push(<Tab id="browse" label={t("form.sqleditor.label.tab.browse")}>{tabIndex === tabs.length && <SqlBrowseTab sqlConnection={sqlConnection} table={dbTable} />}</Tab>);
     }
     tabs.push(<Tab id="query" label={t("form.sqleditor.label.tab.query")}>{tabIndex === tabs.length && <SqlQueryTab sqlConnection={sqlConnection} dbTable={dbTable} />}</Tab>);
-    tabs.push(<Tab id="import" label={t("form.sqleditor.label.tab.import")}>{tabIndex === tabs.length && <SqlImportTab sqlConnection={sqlConnection} dbTable={dbTable} />}</Tab>);
+    tabs.push(<Tab id="import" label={t("form.sqleditor.label.tab.import")}>{tabIndex === tabs.length && <SqlImportTab tasks={tasks} setTasks={setTasks} sqlConnection={sqlConnection} dbTable={dbTable} />}</Tab>);
     return <Tabs currentTab={tabIndex} setCurrentTab={(tabIndex) => setTabIndex(tabIndex)}>{tabs}</Tabs>
 }
 
@@ -89,11 +92,11 @@ function SqlPage(props: PageProps) {
                     {sqlConnection && <ComboBox loadItems={loadTables}
                         selected={dbTable}>
                         <label>{dbTable}</label>
-                    </ComboBox> || <></>}
+                    </ComboBox> || <div></div>}
                 </StyledBreadcrumbs>
             </div>
         </div>
-        {sqlConnection ? <SqlTabs dbTable={dbTable} sqlConnection={sqlConnection} /> : <SqlLogin setSqlConnection={(conn: SqlType) => {
+        {sqlConnection ? <SqlTabs tasks={props.tasks} setTasks={props.setTasks} dbTable={dbTable} sqlConnection={sqlConnection} /> : <SqlLogin setSqlConnection={(conn: SqlType) => {
             setSqlConnection(conn);
         }} />}
     </PageLayout>;

--- a/ui/src/components/pages/parts/Rest.tsx
+++ b/ui/src/components/pages/parts/Rest.tsx
@@ -114,12 +114,11 @@ export class Rest extends React.Component<{ isRecording: boolean, setIsRecording
         })
     }
 
-    static async getStream(path: string, eventsAbortController: AbortController) {
+    static async getStream(url: string, headers: { [key: string]: string }, eventsAbortController: AbortController) {
         return new Promise((resolve, reject) => {
             Rest.incrementPending();
-            const url = Auth.getNuodbCpRestUrl(path);
             axios({
-                headers: { ...Auth.getHeaders(), 'Accept': 'text/event-stream' },
+                headers: { ...headers, 'Accept': 'text/event-stream' },
                 method: 'get',
                 url: url,
                 responseType: 'stream',

--- a/ui/src/components/pages/sql/SqlImportTab.tsx
+++ b/ui/src/components/pages/sql/SqlImportTab.tsx
@@ -1,0 +1,128 @@
+// (C) Copyright 2025 Dassault Systemes SE.  All Rights Reserved.
+
+import React, { useEffect, useState } from 'react';
+import { withTranslation } from "react-i18next";
+import { t } from 'i18next';
+import { SqlImportResponseType, SqlResponse, SqlType } from '../../../utils/SqlSocket';
+import TextField from '../../controls/TextField';
+import Button from '../../controls/Button';
+import SqlResultsRender from './SqlResultsRender';
+import Toast from '../../controls/Toast';
+import CloudUploadIcon from '@mui/icons-material/CloudUpload';
+import axios from 'axios';
+import { Table, TableBody, TableCell, TableHead, TableRow, TableTh } from '../../controls/Table';
+
+type SqlImportTabProps = {
+    sqlConnection: SqlType;
+    dbTable: string;
+}
+function SqlImportTab({ sqlConnection, dbTable }: SqlImportTabProps) {
+    const [executing, setExecuting] = useState(false);
+    const [files, setFiles] = useState<File[]>([]); // files to be uploaded
+    const [sqlImportResponse, setSqlImportResponse] = useState<(SqlImportResponseType|undefined)[]>([]); // upload status. If element is undefined, upload hasn't started yet
+    const [completed, setCompleted] = useState<boolean[]>([]); //status of completion
+
+    function renderFileSelector() {
+        if(files.length !== 0) {
+            return null;
+        }
+
+        return <>
+            <input className="NuoUpload"
+                id="file-upload"
+                type="file"
+                accept="text/sql"
+                multiple={true}
+                onChange={(event) => {
+                    const fl: FileList | null = event.target.files;
+                    let files: File[] = [];
+                    for(let i=0; fl !== null && i<fl.length; i++) {
+                        const flItem = fl.item(i);
+                        if(flItem) {
+                            files.push(flItem);
+                        }
+                    }
+                    setCompleted(files.map(file=>false));
+                    setSqlImportResponse(files.map(file=>undefined))
+                    setFiles(files);
+                }}
+            />
+            <label htmlFor="file-upload" className="NuoUpload">
+                <div className="NuoColumn">
+                    <CloudUploadIcon/>
+                    Select Files
+                </div>
+            </label>
+        </>
+    }
+
+    function renderFileStatus() {
+        if(files.length === 0) {
+            return null;
+        }
+        return <Table>
+            <TableHead>
+                <TableRow>
+                    <TableTh>Filename</TableTh>
+                    <TableTh>Status</TableTh>
+                    <TableTh>Success</TableTh>
+                    <TableTh>Failures</TableTh>
+                    <TableTh>Updates</TableTh>
+                    <TableTh>Error</TableTh>
+                </TableRow>
+            </TableHead>
+            <TableBody>
+                {files.map((file,index)=> {
+                    let stats = sqlImportResponse[index] || {};
+                    return <TableRow key={file.name}>
+                        <TableCell>{file.name}</TableCell>
+                        <TableCell>{sqlImportResponse[index] === undefined ? "Not Started" : completed[index] ? "Done" : "In Progress"}</TableCell>
+                        <TableCell>{stats.success}</TableCell>
+                        <TableCell>{stats.failed}</TableCell>
+                        <TableCell>{stats.updatedRows}</TableCell>
+                    </TableRow>})}
+            </TableBody>
+        </Table>;
+    }
+
+    function renderUploadButton() {
+        if(files.length === 0 || sqlImportResponse.findIndex(i => i !== undefined) !== -1) {
+            return null;
+        }
+
+        return <Button onClick={async () => {
+            for(let i=0; i<files.length; i++) {
+                setSqlImportResponse((response) => {
+                    let r = [...response];
+                    r[i] = {};
+                    return r;
+                });
+                const importResults = await sqlConnection.sqlImport(files[i]);
+                setSqlImportResponse((response) => {
+                    let r = [...response];
+                    r[i] = importResults;
+                    return r;
+                });
+                setCompleted((completed)=>{
+                    let c = [...completed];
+                    c[i] = true;
+                    return c;
+                })
+            }
+        }}>
+            Upload {files.length} files
+        </Button>
+
+    }
+
+    return <><form>
+        <div className="NuoColumn NuoFieldContainer NuoCenter">
+            {renderFileSelector()}
+            {renderFileStatus()}
+            {renderUploadButton()}
+        </div>
+    </form>
+    </>;
+}
+
+export default withTranslation()(SqlImportTab);

--- a/ui/src/components/pages/sql/SqlImportTab.tsx
+++ b/ui/src/components/pages/sql/SqlImportTab.tsx
@@ -4,62 +4,92 @@ import React, { useEffect, useState } from 'react';
 import { withTranslation } from "react-i18next";
 import { t } from 'i18next';
 import { SqlImportResponseType, SqlResponse, SqlType } from '../../../utils/SqlSocket';
-import TextField from '../../controls/TextField';
 import Button from '../../controls/Button';
-import SqlResultsRender from './SqlResultsRender';
-import Toast from '../../controls/Toast';
 import CloudUploadIcon from '@mui/icons-material/CloudUpload';
-import axios from 'axios';
 import { Table, TableBody, TableCell, TableHead, TableRow, TableTh } from '../../controls/Table';
+import BackgroundTasks, { BackgroundTaskType } from '../../../utils/BackgroundTasks';
 
 type SqlImportTabProps = {
     sqlConnection: SqlType;
     dbTable: string;
 }
+
+interface SqlImportData extends SqlImportResponseType {
+    file: File;
+}
+
 function SqlImportTab({ sqlConnection, dbTable }: SqlImportTabProps) {
-    const [executing, setExecuting] = useState(false);
     const [files, setFiles] = useState<File[]>([]); // files to be uploaded
-    const [sqlImportResponse, setSqlImportResponse] = useState<(SqlImportResponseType|undefined)[]>([]); // upload status. If element is undefined, upload hasn't started yet
-    const [completed, setCompleted] = useState<boolean[]>([]); //status of completion
+    const [tasks, setTasks] = useState<BackgroundTaskType[]>(BackgroundTasks.getTasks().filter(task => task.listenerId === "sqlImport"));
+
+    let listenerId = -1;
+
+    useEffect(() => {
+        listenerId = BackgroundTasks.addListener((tasks: BackgroundTaskType[]) => {
+            setTasks(tasks.filter(task => task.listenerId === "sqlImport"));
+        });
+        return () => {
+            BackgroundTasks.removeListener(listenerId);
+        };
+    }, [])
 
     function renderFileSelector() {
-        if(files.length !== 0) {
-            return null;
-        }
-
-        return <>
+        return <div className="NuoColumn NuoCenter">
             <input className="NuoUpload"
                 id="file-upload"
                 type="file"
-                accept="text/sql"
+                accept=".sql"
                 multiple={true}
                 onChange={(event) => {
+                    let updatedFiles: File[] = [...files];
                     const fl: FileList | null = event.target.files;
-                    let files: File[] = [];
                     for(let i=0; fl !== null && i<fl.length; i++) {
                         const flItem = fl.item(i);
                         if(flItem) {
-                            files.push(flItem);
+                            // add file only if it hasn't been added before
+                            if (!updatedFiles.find(f => f.name === flItem.name && f.size === flItem.size && f.lastModified === flItem.lastModified)) {
+                                updatedFiles.push(flItem);
+                            }
                         }
                     }
-                    setCompleted(files.map(file=>false));
-                    setSqlImportResponse(files.map(file=>undefined))
-                    setFiles(files);
+                    setFiles(updatedFiles);
                 }}
             />
             <label htmlFor="file-upload" className="NuoUpload">
                 <div className="NuoColumn">
                     <CloudUploadIcon/>
-                    Select Files
+                    Select SQL Files
                 </div>
             </label>
-        </>
+        </div>
+    }
+
+    function addToQueue(toQueue: File[]) {
+        BackgroundTasks.addTasks(toQueue.map(file => {
+            return {
+                listenerId: "sqlImport",
+                label: file.name,
+                status: "not_started",
+                description: "Importing " + file.name,
+                data: { file: file },
+                execute: async (data: SqlImportData) => {
+                    return { ...data, ... await sqlConnection.sqlImport(data.file) };
+                },
+                show: (data: SqlImportData) => {
+                    return <div key={data.file.name}>{data.file.name}</div>
+                }
+            }
+        }));
+
+        let newFiles = [...files];
+        for (let i = 0; i < toQueue.length; i++) {
+            newFiles = newFiles.filter(f => f.name !== toQueue[i].name || f.lastModified != toQueue[i].lastModified || f.size != toQueue[i].size);
+        }
+
+        setFiles(newFiles);
     }
 
     function renderFileStatus() {
-        if(files.length === 0) {
-            return null;
-        }
         return <Table>
             <TableHead>
                 <TableRow>
@@ -72,54 +102,34 @@ function SqlImportTab({ sqlConnection, dbTable }: SqlImportTabProps) {
                 </TableRow>
             </TableHead>
             <TableBody>
-                {files.map((file,index)=> {
-                    let stats = sqlImportResponse[index] || {};
+                {files.map((file, index) => {
                     return <TableRow key={file.name}>
                         <TableCell>{file.name}</TableCell>
-                        <TableCell>{sqlImportResponse[index] === undefined ? "Not Started" : completed[index] ? "Done" : "In Progress"}</TableCell>
-                        <TableCell>{stats.success}</TableCell>
-                        <TableCell>{stats.failed}</TableCell>
-                        <TableCell>{stats.updatedRows}</TableCell>
+                        <td><Button onClick={() => { addToQueue([file]); }}>Add to Queue</Button></td>
+                        <TableCell></TableCell>
+                        <TableCell></TableCell>
+                        <TableCell></TableCell>
+                    </TableRow>
+                })}
+                {files.length === 0 ? null : <TableRow><TableCell></TableCell><td><Button className="NuoButton" onClick={() => { addToQueue(files); }}>Add all to Queue</Button></td></TableRow>}
+                {tasks.map((task) => {
+                    return <TableRow key={task.data.file.name}>
+                        <TableCell>{task.data.file.name}</TableCell>
+                        <TableCell>{task.status}</TableCell>
+                        <TableCell>{task.data.success}</TableCell>
+                        <TableCell>{task.data.failed}</TableCell>
+                        <TableCell>{task.data.updatedRows}</TableCell>
                     </TableRow>})}
             </TableBody>
         </Table>;
     }
 
-    function renderUploadButton() {
-        if(files.length === 0 || sqlImportResponse.findIndex(i => i !== undefined) !== -1) {
-            return null;
-        }
-
-        return <Button onClick={async () => {
-            for(let i=0; i<files.length; i++) {
-                setSqlImportResponse((response) => {
-                    let r = [...response];
-                    r[i] = {};
-                    return r;
-                });
-                const importResults = await sqlConnection.sqlImport(files[i]);
-                setSqlImportResponse((response) => {
-                    let r = [...response];
-                    r[i] = importResults;
-                    return r;
-                });
-                setCompleted((completed)=>{
-                    let c = [...completed];
-                    c[i] = true;
-                    return c;
-                })
-            }
-        }}>
-            Upload {files.length} files
-        </Button>
-
-    }
-
     return <><form>
         <div className="NuoColumn NuoFieldContainer NuoCenter">
-            {renderFileSelector()}
-            {renderFileStatus()}
-            {renderUploadButton()}
+            <div className="NuoRow">
+                {renderFileSelector()}
+                {renderFileStatus()}
+            </div>
         </div>
     </form>
     </>;

--- a/ui/src/resources/translation/en.json
+++ b/ui/src/resources/translation/en.json
@@ -82,6 +82,12 @@
             "selector.slas": "SLAs",
             "selector.tiers": "Tiers",
             "selector.labels": "Labels",
+            "status.sqlEndpoint": "SQL Endpoint",
+            "status.caPem": "Certificate",
+            "status.ready": "Ready",
+            "status.shutdown": "Shutdown",
+            "status.message": "Message",
+            "status.state": "State",
             "maintenance.expiresAtTime": "Expires at time",
             "maintenance.expiresIn": "Expires in",
             "properties.propagatePolicyLabels": "Propagate policy labels",
@@ -177,7 +183,6 @@
                 "tab": {
                     "browse": "Browse",
                     "query": "Query",
-                    "export": "Export",
                     "import": "Import"
                 }
             },

--- a/ui/src/resources/translation/en.json
+++ b/ui/src/resources/translation/en.json
@@ -176,7 +176,9 @@
                 "value": "Value",
                 "tab": {
                     "browse": "Browse",
-                    "query": "Query"
+                    "query": "Query",
+                    "export": "Export",
+                    "import": "Import"
                 }
             },
             "button": {
@@ -189,7 +191,7 @@
             "label": {
                 "loginWith": "Login With {{providerDesc}} ",
                 "goBack": "Go Back",
-                "login": "Login" 
+                "login": "Login"
             }
         }
     },

--- a/ui/src/utils/BackgroundTaskStatus.tsx
+++ b/ui/src/utils/BackgroundTaskStatus.tsx
@@ -2,6 +2,8 @@
 
 import { BackgroundTaskType } from "./BackgroundTasks";
 import CheckIcon from '@mui/icons-material/Check';
+import CancelIcon from '@mui/icons-material/Cancel';
+import ErrorIcon from '@mui/icons-material/Error';
 import HourglassEmptyIcon from '@mui/icons-material/HourglassEmpty';
 import CircularProgress from "@mui/material/CircularProgress";
 import CircularProgressWithLabel from "../components/controls/CircularProgressWithLabel";
@@ -11,15 +13,22 @@ type BackgroundTasksStatusProps = {
     task: BackgroundTaskType;
     tasks: BackgroundTaskType[];
     setTasks: React.Dispatch<React.SetStateAction<BackgroundTaskType[]>>;
+    abortController?: AbortController;
 };
 
-export default function BackgroundTasksStatus({task, tasks, setTasks}:BackgroundTasksStatusProps) {
+export default function BackgroundTasksStatus({ task, tasks, setTasks, abortController }: BackgroundTasksStatusProps) {
     let statusIcon = null;
     if (task.status === "not_started") {
         statusIcon = <HourglassEmptyIcon />;
     }
     else if (task.status === "complete") {
         statusIcon = <CheckIcon />;
+    }
+    else if (task.status === "canceled") {
+        statusIcon = <CancelIcon />;
+    }
+    else if (task.status === "error") {
+        statusIcon = <ErrorIcon />
     }
     else if (task.status === "in_progress") {
         if (task.percent) {
@@ -30,16 +39,22 @@ export default function BackgroundTasksStatus({task, tasks, setTasks}:Background
         }
     }
 
+    if (!abortController && task.status === "in_progress") {
+        return <div className="NuoRow">{statusIcon}</div>
+    }
+
     return <div className="NuoRow">
         {statusIcon}
         <Button variant="text" onClick={() => {
-            if (task.status === "complete" || task.status === "not_started") {
+            if (task.status === "in_progress") {
+                abortController?.abort();
+            }
+            else {
                 const newTasks = tasks.filter((t: BackgroundTaskType) => t.id != task.id);
-                console.log("STATUS", newTasks, tasks);
                 setTasks(newTasks);
             }
         }}>
-            {task.status === "complete" && "Dismiss"}
+            {(task.status === "complete" || task.status === "canceled" || task.status === "error") && "Dismiss"}
             {task.status === "in_progress" && "Cancel"}
             {task.status === "not_started" && "Cancel"}
         </Button>

--- a/ui/src/utils/BackgroundTasks.tsx
+++ b/ui/src/utils/BackgroundTasks.tsx
@@ -2,7 +2,7 @@
 
 import React, { ReactNode } from "react";
 
-export type StatusType = "not_started" | "in_progress" | "complete";
+export type StatusType = "not_started" | "in_progress" | "complete" | "canceled" | "error";
 export type BackgroundTaskType = {
     id: string;
     label: string;
@@ -11,7 +11,6 @@ export type BackgroundTaskType = {
     status: StatusType;
     percent?: number;
     execute: (data: any) => Promise<any>;
-    show: (task: BackgroundTaskType) => ReactNode;
     showMinimal: (task: BackgroundTaskType, tasks: BackgroundTaskType[], setTasks: React.Dispatch<React.SetStateAction<BackgroundTaskType[]>>) => ReactNode;
 };
 
@@ -33,7 +32,9 @@ export function launchNextBackgroundTask(tasks: BackgroundTaskType[], setTasks: 
             setTasks(tasks);
             tasks[i].execute(tasks[i]).then(task => {
                 setTasks((previousTasks: BackgroundTaskType[]) => {
-                    task.status = "complete";
+                    if (task.status === "in_progress") {
+                        task.status = "complete";
+                    }
                     let newTasks = [...previousTasks];
                     const taskIndex = newTasks.findIndex(t => t.id === task.id);
                     if (taskIndex != -1) {
@@ -82,8 +83,8 @@ export default function BackgroundTasks({ tasks, setTasks }: BackgroundTasksProp
         if (tasks.length === 0) {
             return null;
         }
-        const summary = String(tasks.filter(task => task.status === "complete").length) + " of " + String(tasks.length) + " Tasks complete";
+    const summary = String(tasks.filter(task => task.status !== "not_started" && task.status !== "in_progress").length) + " of " + String(tasks.length) + " Tasks complete";
         return <details className="NuoBackgroundTasksStatus"><summary>{summary}</summary>
-            {tasks.map(task => <div key={task.id}>{task.showMinimal(task, tasks, setTasks)}</div>)}
+            {tasks.map(task => <div className="NuoRow" key={task.id}>{task.showMinimal(task, tasks, setTasks)}</div>)}
         </details>;
 }

--- a/ui/src/utils/BackgroundTasks.tsx
+++ b/ui/src/utils/BackgroundTasks.tsx
@@ -1,0 +1,20 @@
+// (C) Copyright 2025 Dassault Systemes SE.  All Rights Reserved.
+
+import React, { createContext, ReactNode } from "react";
+
+export type StatusType = "Not Started" | "In Progress" | "Complete";
+type BackgroundTaskType = {
+    label: string;
+    data: any;
+    status: StatusType;
+    execute: (data: any) => Promise<void>;
+    show: (data: any) => ReactNode;
+    showMinimal: (data:any) => ReactNode;
+    children: ReactNode;
+}
+
+export function addBackgroundTask() {
+
+}
+
+export const BackgroundTasks = createContext<BackgroundTaskType[]>([]);

--- a/ui/src/utils/BackgroundTasks.tsx
+++ b/ui/src/utils/BackgroundTasks.tsx
@@ -1,20 +1,130 @@
 // (C) Copyright 2025 Dassault Systemes SE.  All Rights Reserved.
 
-import React, { createContext, ReactNode } from "react";
+import CircularProgress from "@mui/material/CircularProgress";
+import React, { Component, createContext, ReactNode, useContext } from "react";
+import CheckIcon from '@mui/icons-material/Check';
+import HourglassEmptyIcon from '@mui/icons-material/HourglassEmpty';
 
-export type StatusType = "Not Started" | "In Progress" | "Complete";
-type BackgroundTaskType = {
+export type StatusType = "not_started" | "in_progress" | "complete";
+export type BackgroundTaskType = {
+    listenerId: string;
     label: string;
+    description: string;
     data: any;
     status: StatusType;
-    execute: (data: any) => Promise<void>;
+    execute: (data: any) => Promise<any>;
     show: (data: any) => ReactNode;
-    showMinimal: (data:any) => ReactNode;
-    children: ReactNode;
+};
+
+export type BackgroundTasksContextType = {
+    tasks: BackgroundTaskType[];
+    addBackgroundTask: (task: BackgroundTaskType) => void;
+    execute: () => void;
 }
 
-export function addBackgroundTask() {
-
+interface IProps {
 }
 
-export const BackgroundTasks = createContext<BackgroundTaskType[]>([]);
+type ListenerCallback = (tasks: BackgroundTaskType[]) => void;
+
+interface IState {
+    tasks: BackgroundTaskType[];
+    listeners: { [key: number]: ListenerCallback };
+}
+
+let s_instance: BackgroundTasks | undefined = undefined;
+let listenerIndex = 0;
+
+function tasksUpdatedCallback() {
+    if (!s_instance) {
+        return;
+    }
+    BackgroundTasks.launch();
+    const listeners: ListenerCallback[] = Object.values(s_instance.state.listeners);
+    listeners.forEach(listener => {
+        if (s_instance) {
+            listener(s_instance.state.tasks);
+        }
+    });
+}
+export default class BackgroundTasks extends Component<IProps, IState> {
+    state = {
+        tasks: [],
+        listeners: {}
+    }
+
+    componentDidMount() {
+        s_instance = this;
+    }
+
+    static getTasks(): BackgroundTaskType[] {
+        if (!s_instance) {
+            return [];
+        }
+        return s_instance.state.tasks;
+    }
+
+    static addTasks(newTasks: BackgroundTaskType[]) {
+        if (!s_instance) {
+            return;
+        }
+        const tasks = [...s_instance?.state.tasks, ...newTasks];
+        s_instance.setState({ tasks }, tasksUpdatedCallback);
+    }
+
+    static addListener(listener: ListenerCallback): number {
+        if (!s_instance) {
+            return -1;
+        }
+        s_instance.setState({ listeners: { ...s_instance.state.listeners, [listenerIndex++]: listener } });
+        return listenerIndex;
+    }
+
+    static removeListener(index: number) {
+        if (!s_instance) {
+            return;
+        }
+        let newListeners: { [key: number]: ListenerCallback } = { ...s_instance.state.listeners };
+        delete newListeners[index];
+    }
+
+    static launch() {
+        if (!s_instance) {
+            return;
+        }
+        const tasks: BackgroundTaskType[] = s_instance.state.tasks
+        for (let i = 0; i < tasks.length; i++) {
+            if (tasks[i].status === "not_started") {
+                tasks[i].status = "in_progress";
+                s_instance.setState({ tasks }, tasksUpdatedCallback);
+                console.log("EXECUTE", i, tasks[i]);
+                tasks[i].execute(tasks[i].data).then(data => {
+                    console.log("finished", i, tasks[i]);
+                    tasks[i].data = data;
+                    tasks[i].status = "complete";
+                    s_instance?.setState({ tasks }, tasksUpdatedCallback);
+                })
+                break;
+            }
+            else if (tasks[i].status === "in_progress") {
+                break;
+            }
+        }
+    }
+
+    render() {
+        let tasks: BackgroundTaskType[] = this.state.tasks;
+        if (tasks.length === 0) {
+            return null;
+        }
+        const summary = String(tasks.filter(task => task.status === "complete").length) + " of " + String(tasks.length) + " Tasks complete";
+        return <details className="NuoBackgroundTasksStatus"><summary>{summary}</summary>
+            {tasks.map(task => <div>
+                {task.label}
+                {task.status === "not_started" && <HourglassEmptyIcon />}
+                {task.status === "in_progress" && <CircularProgress size="30px" />}
+                {task.status === "complete" && <CheckIcon />}
+            </div>)}
+        </details>;
+    }
+}

--- a/ui/src/utils/BackgroundTasksStatus.tsx
+++ b/ui/src/utils/BackgroundTasksStatus.tsx
@@ -1,0 +1,47 @@
+// (C) Copyright 2025 Dassault Systemes SE.  All Rights Reserved.
+
+import { BackgroundTaskType } from "./BackgroundTasks";
+import CheckIcon from '@mui/icons-material/Check';
+import HourglassEmptyIcon from '@mui/icons-material/HourglassEmpty';
+import CircularProgress from "@mui/material/CircularProgress";
+import CircularProgressWithLabel from "../components/controls/CircularProgressWithLabel";
+import Button from "../components/controls/Button";
+
+type BackgroundTasksStatusProps = {
+    task: BackgroundTaskType;
+    tasks: BackgroundTaskType[];
+    setTasks: React.Dispatch<React.SetStateAction<BackgroundTaskType[]>>;
+};
+
+export default function BackgroundTasksStatus({task, tasks, setTasks}:BackgroundTasksStatusProps) {
+    let statusIcon = null;
+    if (task.status === "not_started") {
+        statusIcon = <HourglassEmptyIcon />;
+    }
+    else if (task.status === "complete") {
+        statusIcon = <CheckIcon />;
+    }
+    else if (task.status === "in_progress") {
+        if (task.percent) {
+            statusIcon = <CircularProgressWithLabel variant="indeterminate" size="30px" value={task.percent} />;
+        }
+        else {
+            statusIcon = <CircularProgress variant="indeterminate" size="30px" />;
+        }
+    }
+
+    return <div className="NuoRow">
+        {statusIcon}
+        <Button variant="text" onClick={() => {
+            if (task.status === "complete" || task.status === "not_started") {
+                const newTasks = tasks.filter((t: BackgroundTaskType) => t.id != task.id);
+                console.log("STATUS", newTasks, tasks);
+                setTasks(newTasks);
+            }
+        }}>
+            {task.status === "complete" && "Dismiss"}
+            {task.status === "in_progress" && "Cancel"}
+            {task.status === "not_started" && "Cancel"}
+        </Button>
+    </div>;
+}

--- a/ui/src/utils/SqlSocket.ts
+++ b/ui/src/utils/SqlSocket.ts
@@ -48,6 +48,8 @@ export type SqlImportResponseType = {
     updatedRows?: number;
     failedQueries?: string[];
     error?: string;
+    progressKey?: string;
+    bytesProcessed?: number;
 }
 
 export type SqlExportParams = {

--- a/ui/src/utils/schema.ts
+++ b/ui/src/utils/schema.ts
@@ -261,7 +261,7 @@ export function getFilterField(rootSchema: TempAny, path: string): string|null|s
     }
 }
 
-function concatChunks(chunk1: Uint8Array, chunk2: Uint8Array) : Uint8Array {
+export function concatChunks(chunk1: Uint8Array, chunk2: Uint8Array) : Uint8Array {
     let ret = new Uint8Array(chunk1.length + chunk2.length);
     ret.set(chunk1, 0);
     ret.set(chunk2, chunk1.length);
@@ -285,7 +285,7 @@ export function getResourceEvents(path: string, multiResolve: TempAny, multiReje
     //only one event stream is supported - close prior one if it exists.
     let eventsAbortController = new AbortController();
 
-    Rest.getStream("events" + path, eventsAbortController)
+    Rest.getStream(Auth.getNuodbCpRestUrl("events" + path), Auth.getHeaders(), eventsAbortController)
       .then(async (response: TempAny) => {
         monitoredPaths.add(path.split("?")[0]);
         let event = null;

--- a/ui/src/utils/types.ts
+++ b/ui/src/utils/types.ts
@@ -1,6 +1,7 @@
 // (C) Copyright 2024-2025 Dassault Systemes SE.  All Rights Reserved.
 
 import { ReactNode } from "react";
+import { BackgroundTaskType } from "./BackgroundTasks";
 
 // the TempAny type allows us to temporarily declare variables as "any" type,
 // so we can easily find them in source control and fix in future PR's
@@ -76,5 +77,7 @@ export interface PageProps {
     org: string,
     setOrg: (org: string) => void;
     orgs: string[];
+    tasks: BackgroundTaskType[];
+    setTasks: React.Dispatch<React.SetStateAction<BackgroundTaskType[]>>;
     t: any
 };


### PR DESCRIPTION
When selecting the "SQL Editor" on the database view menu popup and then selecting the "Import" tab, one can upload small and large SQL files to be imported to the database.
This required the creation of a `BackgroundTask` component to show the background tasks at the bottom right (which will stay active even when changing pages).
When background tasks are active and the user leaves the page, a popup will appear that data loss may occur (unfortunately there is an additional browser popup which cannot be customized due to security / spam concerns).