### PR TITLE
Add combo-box support for the organization/project/database fields

### DIFF
--- a/ui/src/components/fields/FieldFactory.tsx
+++ b/ui/src/components/fields/FieldFactory.tsx
@@ -61,7 +61,7 @@ const FieldFactory = {
             else if (props.parameter["x-tf-sensitive"] === true) {
                 return FieldPassword(props);
             }
-            else if (props.parameter.enum) {
+            else if (props.parameter.enum && !props.readonly) {
                 return FieldSelect(props);
             }
             else if (props.prefix === "frequency" && (props.path === "/backuppolicies" || props.path.startsWith("/backuppolicies/"))) {

--- a/ui/src/components/pages/parts/Path.tsx
+++ b/ui/src/components/pages/parts/Path.tsx
@@ -7,7 +7,6 @@ import Select, { SelectOption } from "../../controls/Select"
 import Link from '@mui/material/Link'
 import Typography from '@mui/material/Typography';
 import { styled } from '@mui/material';
-import { RestSpinner } from './Rest';
 import { getFilterField, getSchemaPath } from "../../../utils/schema";
 import { SchemaType } from "../../../utils/types"
 
@@ -84,7 +83,6 @@ function Path({ schema, path, prefixLabel, postfixLabel, filterValues, org, t }:
             {postfixLabel && <Typography key="management" color="text.primary" style={{ fontSize: "1em", textWrap: "nowrap" }}>{postfixLabel}</Typography>}
             {renderFilter()}
         </StyledBreadcrumbs>
-        <RestSpinner />
     </div>;
 }
 

--- a/ui/src/components/pages/parts/Rest.tsx
+++ b/ui/src/components/pages/parts/Rest.tsx
@@ -94,7 +94,10 @@ export class Rest extends React.Component<{ isRecording: boolean, setIsRecording
     }
 
     render(): ReactNode {
-        return null;
+        return this.state.pendingRequests > 0 ?
+            <CircularProgress className="RestSpinner" color="inherit" />
+            :
+            <div data-testid="rest_spinner__complete" className="RestSpinner">&nbsp;</div>;
     }
 
     static async get(path: string) {
@@ -205,16 +208,4 @@ export class Rest extends React.Component<{ isRecording: boolean, setIsRecording
                 })
         });
     }
-}
-
-export function RestSpinner() {
-    if (!instance) return null;
-
-    return <React.Fragment>
-        {instance.state.pendingRequests > 0 ?
-            <CircularProgress className="RestSpinner" color="inherit" />
-            :
-            <div data-testid="rest_spinner__complete" className="RestSpinner">&nbsp;</div>
-        }
-    </React.Fragment>;
 }


### PR DESCRIPTION
This replaces the text fields for the "organization", "project" and "database" fields into combo boxes by filling in the `enum` property with appropriate values. Since the `name` field is used for the name of the current resource (i.e. the database name of the `database` resource is in the `name` field, not a `database` field), we can distinguish text fields / combo box fields by the field names `organization`, `project` and `database`.

Also fixed flaky tests by fixing the RestSpinner - before, a single state was used in two components - now it's all in one component fixing refresh issues on the second component.