### PR TITLE
recreate SSE connections if they are disconnected by the server

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -190,7 +190,7 @@ deploy-operator-from-aws: aws-login $(KIND) $(HELM)
 	$(HELM_OPERATOR_SETTINGS)
 
 .PHONY: deploy-operator
-deploy-operator: build-cp nuodb.lic $(HELM) $(KIND)
+deploy-operator: build-cp nuodb.lic $(KUBECTL) $(HELM) $(KIND)
 	@if [ -d $(NUODB_CP_REPO)/charts/nuodb-cp-operator ] ; then \
 		$(KIND) load docker-image nuodb/nuodb-control-plane:latest; \
 		$(HELM) dependency update $(NUODB_CP_REPO)/charts/nuodb-cp-operator; \
@@ -204,6 +204,7 @@ deploy-operator: build-cp nuodb.lic $(HELM) $(KIND)
 		$(HELM) upgrade --install --wait -n default nuodb-operator nuodb-cp-operator --repo https://nuodb.github.io/nuodb-cp-releases/charts --version $(NUODB_CP_VERSION) \
         $(HELM_OPERATOR_SETTINGS); \
 	fi
+	-$(KUBECTL) apply -n default -f docker/production/nano-resources.yaml
 
 .PHONY: undeploy-operator
 undeploy-operator: $(KIND) $(HELM)

--- a/Makefile
+++ b/Makefile
@@ -326,6 +326,30 @@ setup-integration-tests: $(KUBECTL) setup-nginx-default-conf install-crds deploy
 		--data-binary \
             '{\"password\":\"passw0rd\", \"name\":\"admin\", \"organization\": \"integrationtest\", \"accessRule\":{\"allow\": [\"all:integrationtest\",\"all:integrationtest2\",\"all:/cluster/*\"]}}' \
 		-X PUT -H \"Content-Type: application/json\" > /dev/null"
+	@$(KUBECTL) exec -n default -it $(shell ${KUBECTL} get pod -n default -l "app=nuodb-cp-rest" -o name) -- bash -c "curl \
+		https://localhost:8080/api/projects/integrationtest/keepproject \
+		--data-binary \
+			'{\"sla\": \"dev\", \"tier\": \"n0.small\"}' \
+		-X PUT -H \"Content-Type: application/json\"" > /dev/null"
+	@$(KUBECTL) exec -n default -it $(shell ${KUBECTL} get pod -n default -l "app=nuodb-cp-rest" -o name) -- bash -c "curl \
+		https://localhost:8080/api/databases/integrationtest/keepproject/keepdb1 \
+		--data-binary \
+			'{"dbaPassword": "passw0rd"}' \
+		-X PUT -H \"Content-Type: application/json\" > /dev/null"
+	@$(KUBECTL) exec -n default -it $(shell ${KUBECTL} get pod -n default -l "app=nuodb-cp-rest" -o name) -- bash -c " \
+		RETRY=0; \
+		while [ $$RETRY -lt 36 ] ; do \
+			echo "Waiting for Database to become available ($$RETRY/36)"; \
+			AVAILABLE=$$(curl https://localhost:8080/api/databases/integrationtest/keepproject/keepdb1 -H \"Content-Type: application/json\" 2> /dev/null | grep -e AVAILABLE); \
+			if [ \"$$AVAILABLE\" = \"Available\" ] ; then
+				echo "Database is available"; \
+				exit 0; \
+			else \
+				sleep 5; \
+				((RETRY++)); \
+			fi; \
+		done; \
+		exit 1"
 	$(KUBECTL) apply -n default -f selenium-tests/files/cas-idp.yaml
 	$(KUBECTL) apply -n default -f selenium-tests/files/nuodb-cp-image-versions.yaml
 	@docker ps

--- a/Makefile
+++ b/Makefile
@@ -339,10 +339,10 @@ setup-integration-tests: $(KUBECTL) setup-nginx-default-conf install-crds deploy
 	@$(KUBECTL) exec -n default -it $(shell ${KUBECTL} get pod -n default -l "app=nuodb-cp-rest" -o name) -- bash -c " \
 		RETRY=0; \
 		while [ $$RETRY -lt 36 ] ; do \
-			echo "Waiting for Database to become available ($$RETRY/36)"; \
+			echo \"Waiting for Database to become available ($$RETRY/36)\"; \
 			AVAILABLE=$$(curl https://localhost:8080/api/databases/integrationtest/keepproject/keepdb1 -H \"Content-Type: application/json\" 2> /dev/null | grep -e AVAILABLE); \
 			if [ \"$$AVAILABLE\" = \"Available\" ] ; then
-				echo "Database is available"; \
+				echo \"Database is available\"; \
 				exit 0; \
 			else \
 				sleep 5; \

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,8 @@ ARCH := $(shell uname -m | sed "s/x86_64/amd64/g" | sed "s/aarch64/arm64/g")
 KIND_VERSION ?= 0.27.0
 KUBECTL_VERSION ?= 1.28.3
 HELM_VERSION ?= 3.16.2
+NUODB_VERSION ?= 7.0.2
+NUODB_COLLECTOR_VERSION ?= 2.0.0
 NUODB_CP_VERSION ?= 2.10.0
 NUODB_SQL_VERSION ?= 1.1.0
 PROMETHEUS_VERSION ?= 79.6.1
@@ -116,6 +118,18 @@ aws-login:
 pull-cp-from-ecr: aws-login
 	docker pull ${ECR_ACCOUNT_URL}/nuodb/nuodb-control-plane:$(NUODB_CP_VERSION)-main-latest \
 	&& docker tag ${ECR_ACCOUNT_URL}/nuodb/nuodb-control-plane:$(NUODB_CP_VERSION)-main-latest nuodb/nuodb-control-plane
+
+.PHONY: pull-nuodb-from-ecr
+pull-nuodb-from-ecr: aws-login
+	docker pull --platform linux/amd64 --platform linux/arm64 ${ECR_ACCOUNT_URL}/docker-hub/nuodb/nuodb:$(NUODB_VERSION) \
+	&& docker tag ${ECR_ACCOUNT_URL}/docker-hub/nuodb/nuodb:$(NUODB_VERSION) nuodb/nuodb:$(NUODB_VERSION) \
+	&& docker pull --platform linux/amd64 --platform linux/arm64 ${ECR_ACCOUNT_URL}/docker-hub/nuodb/nuodb-collector:$(NUODB_COLLECTOR_VERSION) \
+	&& docker tag ${ECR_ACCOUNT_URL}/docker-hub/nuodb/nuodb-collector:$(NUODB_COLLECTOR_VERSION) nuodb/nuodb-collector:$(NUODB_COLLECTOR_VERSION)
+
+.PHONY: deploy-nuodb-to-k8s
+deploy-nuodb-to-k8s: pull-nuodb-from-ecr
+	$(KIND) load docker-image nuodb/nuodb:$(NUODB_VERSION) \
+	&& $(KIND) load docker-image nuodb/nuodb-collector:$(NUODB_COLLECTOR_VERSION)
 
 .PHONY: build-cp
 build-cp:
@@ -318,6 +332,14 @@ setup-integration-tests: $(KUBECTL) setup-nginx-default-conf install-crds deploy
 	@$(KUBECTL) describe ingress -A
 	@$(KUBECTL) describe pods -A
 	@$(KUBECTL) get pods -A
+	@if [ "${AWS_REGION}" != "" ] && [ "${AWS_ACCESS_KEY_ID}" != "" ] && [ "${AWS_SECRET_ACCESS_KEY}" != "" ] ; then \
+		${MAKE} deploy-nuodb-to-k8s; \
+	else \
+		echo "****************************************************************************************"; \
+		echo "* WARNING: AWS secret keys not specified. Cannot download nuodb docker image from ECR. *"; \
+		echo "* Falling back to docker.io download (which may block due to too many requests)        *"; \
+		echo "****************************************************************************************"; \
+	fi
 
 .PHONY: teardown-integration-tests
 teardown-integration-tests: $(KIND) undeploy-sql undeploy-webui undeploy-selenium undeploy-cas-server undeploy-keycloak undeploy-operator undeploy-cp undeploy-monitoring uninstall-crds ## clean up containers used by integration tests

--- a/Makefile
+++ b/Makefile
@@ -315,7 +315,7 @@ setup-nginx-default-conf:
 	fi
 
 .PHONY: setup-integration-tests
-setup-integration-tests: $(KUBECTL) setup-nginx-default-conf install-crds deploy-monitoring deploy-cp deploy-operator deploy-sql deploy-keycloak deploy-cas-server deploy-webui ## setup containers before running integration tests
+setup-integration-tests: $(KUBECTL)  ## setup containers before running integration tests
 	@$(KUBECTL) exec -n default -it $(shell ${KUBECTL} get pod -n default -l "app=nuodb-cp-rest" -o name) -- bash -c "curl \
 		http://localhost:8080/users/acme/admin?allowCrossOrganizationAccess=true \
 		--data-binary \
@@ -330,7 +330,7 @@ setup-integration-tests: $(KUBECTL) setup-nginx-default-conf install-crds deploy
 		https://localhost:8080/api/projects/integrationtest/keepproject \
 		--data-binary \
 			'{\"sla\": \"dev\", \"tier\": \"n0.small\"}' \
-		-X PUT -H \"Content-Type: application/json\"" > /dev/null"
+		-X PUT -H \"Content-Type: application/json\" > /dev/null"
 	@$(KUBECTL) exec -n default -it $(shell ${KUBECTL} get pod -n default -l "app=nuodb-cp-rest" -o name) -- bash -c "curl \
 		https://localhost:8080/api/databases/integrationtest/keepproject/keepdb1 \
 		--data-binary \

--- a/Makefile
+++ b/Makefile
@@ -315,7 +315,7 @@ setup-nginx-default-conf:
 	fi
 
 .PHONY: setup-integration-tests
-setup-integration-tests: $(KUBECTL)  ## setup containers before running integration tests
+setup-integration-tests: $(KUBECTL) setup-nginx-default-conf install-crds deploy-monitoring deploy-cp deploy-operator deploy-sql deploy-keycloak deploy-cas-server deploy-webui ## setup containers before running integration tests
 	@$(KUBECTL) exec -n default -it $(shell ${KUBECTL} get pod -n default -l "app=nuodb-cp-rest" -o name) -- bash -c "curl \
 		http://localhost:8080/users/acme/admin?allowCrossOrganizationAccess=true \
 		--data-binary \

--- a/Makefile
+++ b/Makefile
@@ -121,9 +121,9 @@ pull-cp-from-ecr: aws-login
 
 .PHONY: pull-nuodb-from-ecr
 pull-nuodb-from-ecr: aws-login
-	docker pull --platform linux/amd64 --platform linux/arm64 ${ECR_ACCOUNT_URL}/docker-hub/nuodb/nuodb:$(NUODB_VERSION) \
+	docker pull --platform linux/${ARCH} ${ECR_ACCOUNT_URL}/docker-hub/nuodb/nuodb:$(NUODB_VERSION) \
 	&& docker tag ${ECR_ACCOUNT_URL}/docker-hub/nuodb/nuodb:$(NUODB_VERSION) nuodb/nuodb:$(NUODB_VERSION) \
-	&& docker pull --platform linux/amd64 --platform linux/arm64 ${ECR_ACCOUNT_URL}/docker-hub/nuodb/nuodb-collector:$(NUODB_COLLECTOR_VERSION) \
+	&& docker pull --platform linux/${ARCH} ${ECR_ACCOUNT_URL}/docker-hub/nuodb/nuodb-collector:$(NUODB_COLLECTOR_VERSION) \
 	&& docker tag ${ECR_ACCOUNT_URL}/docker-hub/nuodb/nuodb-collector:$(NUODB_COLLECTOR_VERSION) nuodb/nuodb-collector:$(NUODB_COLLECTOR_VERSION)
 
 .PHONY: deploy-nuodb-to-k8s
@@ -326,36 +326,9 @@ setup-integration-tests: $(KUBECTL) setup-nginx-default-conf install-crds deploy
 		--data-binary \
             '{\"password\":\"passw0rd\", \"name\":\"admin\", \"organization\": \"integrationtest\", \"accessRule\":{\"allow\": [\"all:integrationtest\",\"all:integrationtest2\",\"all:/cluster/*\"]}}' \
 		-X PUT -H \"Content-Type: application/json\" > /dev/null"
-	@$(KUBECTL) exec -n default -it $(shell ${KUBECTL} get pod -n default -l "app=nuodb-cp-rest" -o name) -- bash -c "curl \
-		https://localhost:8080/api/projects/integrationtest/keepproject \
-		--data-binary \
-			'{\"sla\": \"dev\", \"tier\": \"n0.small\"}' \
-		-X PUT -H \"Content-Type: application/json\" > /dev/null"
-	@$(KUBECTL) exec -n default -it $(shell ${KUBECTL} get pod -n default -l "app=nuodb-cp-rest" -o name) -- bash -c "curl \
-		https://localhost:8080/api/databases/integrationtest/keepproject/keepdb1 \
-		--data-binary \
-			'{"dbaPassword": "passw0rd"}' \
-		-X PUT -H \"Content-Type: application/json\" > /dev/null"
-	@$(KUBECTL) exec -n default -it $(shell ${KUBECTL} get pod -n default -l "app=nuodb-cp-rest" -o name) -- bash -c " \
-		RETRY=0; \
-		while [ $$RETRY -lt 36 ] ; do \
-			echo \"Waiting for Database to become available ($$RETRY/36)\"; \
-			AVAILABLE=$$(curl https://localhost:8080/api/databases/integrationtest/keepproject/keepdb1 -H \"Content-Type: application/json\" 2> /dev/null | grep -e AVAILABLE); \
-			if [ \"$$AVAILABLE\" = \"Available\" ] ; then
-				echo \"Database is available\"; \
-				exit 0; \
-			else \
-				sleep 5; \
-				((RETRY++)); \
-			fi; \
-		done; \
-		exit 1"
 	$(KUBECTL) apply -n default -f selenium-tests/files/cas-idp.yaml
 	$(KUBECTL) apply -n default -f selenium-tests/files/nuodb-cp-image-versions.yaml
 	@docker ps
-	@$(KUBECTL) describe ingress -A
-	@$(KUBECTL) describe pods -A
-	@$(KUBECTL) get pods -A
 	@if [ "${AWS_REGION}" != "" ] && [ "${AWS_ACCESS_KEY_ID}" != "" ] && [ "${AWS_SECRET_ACCESS_KEY}" != "" ] ; then \
 		${MAKE} deploy-nuodb-to-k8s; \
 	else \
@@ -364,6 +337,10 @@ setup-integration-tests: $(KUBECTL) setup-nginx-default-conf install-crds deploy
 		echo "* Falling back to docker.io download (which may block due to too many requests)        *"; \
 		echo "****************************************************************************************"; \
 	fi
+	./build_utils.sh createProjectAndDatabase
+	@$(KUBECTL) describe ingress -A
+	@$(KUBECTL) describe pods -A
+	@$(KUBECTL) get pods -A
 
 .PHONY: teardown-integration-tests
 teardown-integration-tests: $(KIND) undeploy-sql undeploy-webui undeploy-selenium undeploy-cas-server undeploy-keycloak undeploy-operator undeploy-cp undeploy-monitoring uninstall-crds ## clean up containers used by integration tests

--- a/Makefile
+++ b/Makefile
@@ -302,8 +302,6 @@ setup-nginx-default-conf:
 
 .PHONY: setup-integration-tests
 setup-integration-tests: $(KUBECTL) setup-nginx-default-conf install-crds deploy-monitoring deploy-cp deploy-operator deploy-sql deploy-keycloak deploy-cas-server deploy-webui ## setup containers before running integration tests
-	@npx playwright install || true
-
 	@$(KUBECTL) exec -n default -it $(shell ${KUBECTL} get pod -n default -l "app=nuodb-cp-rest" -o name) -- bash -c "curl \
 		http://localhost:8080/users/acme/admin?allowCrossOrganizationAccess=true \
 		--data-binary \
@@ -331,7 +329,8 @@ teardown-integration-tests: $(KIND) undeploy-sql undeploy-webui undeploy-seleniu
 
 .PHONY: run-integration-tests-only
 run-integration-tests-only: ## integration tests without setup/teardown
-	@cd ui-test && npm install && npm run e2e -- --workers 1 && cd ..
+	@cd ui && npm install && cd ..
+	@cd ui-test && npm install && npx playwright install && npm run e2e -- --workers 1 && cd
 
 .PHONY: run-unit-tests
 run-unit-tests: ## run unit tests

--- a/build_utils.sh
+++ b/build_utils.sh
@@ -197,7 +197,7 @@ if [ "$1" == "createProjectAndDatabase" ] ; then
         echo "Unable to find Control Plane Pod"
         exit 1
     fi
-	./bin/kubectl exec -n default -it ${CP_POD} -- nuodb-cp project create integrationtest/keepproject --sla=dev --tier=n0.small || true
+	./bin/kubectl exec -n default -it ${CP_POD} -- nuodb-cp project create integrationtest/keepproject --sla=dev --tier=n0.nano || true
 	./bin/kubectl exec -n default -it ${CP_POD} -- nuodb-cp database create integrationtest/keepproject/keepdb1 --dba-password=passw0rd || true
     for i in {1..36}; do
         STATE=$(./bin/kubectl exec -n default -it ${CP_POD} -- nuodb-cp database get integrationtest/keepproject/keepdb1 | grep -e "\"state\"") || true

--- a/build_utils.sh
+++ b/build_utils.sh
@@ -210,6 +210,11 @@ if [ "$1" == "createProjectAndDatabase" ] ; then
            sleep 5
         fi
     done;
+	./bin/kubectl describe pods -A
+    ./bin/kubectl get pvc -A
+    ./bin/kubectl get pv -A
+	./bin/kubectl get pods -A
+
     exit 1
 fi
 

--- a/build_utils.sh
+++ b/build_utils.sh
@@ -191,6 +191,28 @@ if [ "$1" == "createRelease" ] && [ "$2" != "" ] ; then
     fi
 fi
 
+if [ "$1" == "createProjectAndDatabase" ] ; then
+    CP_POD=$(./bin/kubectl get pod -n default -l "app=nuodb-cp-rest" -o name)
+    if [ "$CP_POD" = "" ] ; then
+        echo "Unable to find Control Plane Pod"
+        exit 1
+    fi
+	./bin/kubectl exec -n default -it ${CP_POD} -- nuodb-cp project create integrationtest/keepproject --sla=dev --tier=n0.small || true
+	./bin/kubectl exec -n default -it ${CP_POD} -- nuodb-cp database create integrationtest/keepproject/keepdb1 --dba-password=passw0rd || true
+    for i in {1..36}; do
+        STATE=$(./bin/kubectl exec -n default -it ${CP_POD} -- nuodb-cp database get integrationtest/keepproject/keepdb1 | grep -e "\"state\"") || true
+        AVAILABLE=$(echo "$STATE" | grep -e "Available") || true
+        if [ "$AVAILABLE" != "" ] ; then
+            echo "Database is available"
+            exit 0
+        else
+            echo "Waiting for Database to become available ($i/36). ${STATE}"
+           sleep 5
+        fi
+    done;
+    exit 1
+fi
+
 if [ "$1" != "" ] ; then
     echo "Invalid first argument: \"$1\""
 fi
@@ -199,3 +221,4 @@ echo "$0 doesImageExist"
 echo "$0 createAndUploadHelmPackage"
 echo "$0 deployDockerImages"
 echo "$0 createRelease <version number>"
+echo "$0 createProjectAndDatabase"

--- a/build_utils.sh
+++ b/build_utils.sh
@@ -211,6 +211,7 @@ if [ "$1" == "createProjectAndDatabase" ] ; then
         fi
     done;
 	./bin/kubectl describe pods -A
+    ./bin/kubectl get pods -A -o=custom-columns="NAME:.metadata.name,NAMESPACE:.metadata.namespace,LIMITS:.spec.containers[*].resources.limits,REQUESTS:.spec.containers[*].resources.requests"
     ./bin/kubectl get pvc -A
     ./bin/kubectl get pv -A
 	./bin/kubectl get pods -A

--- a/charts/nuodbaas-webui/Chart.yaml
+++ b/charts/nuodbaas-webui/Chart.yaml
@@ -12,5 +12,5 @@ maintainers:
   email: support@nuodb.com
 icon: https://raw.githubusercontent.com/nuodb/nuodb-helm-charts/master/images/nuodb.svg
 type: application
-version: "1.3.2"
-appVersion: "1.3.2"
+version: "1.4.0"
+appVersion: "1.4.0"

--- a/docker/production/nano-resources.yaml
+++ b/docker/production/nano-resources.yaml
@@ -1,0 +1,34 @@
+# (C) Copyright 2026 Dassault Systemes SE.  All Rights Reserved.
+apiVersion: cp.nuodb.com/v1beta1
+kind: HelmFeature
+metadata:
+  name: nano-resources
+spec:
+  values:
+    admin:
+      resources:
+        limits:
+          cpu: 250m
+          memory: 500Mi
+        requests:
+          cpu: 250m
+          memory: 500Mi
+    database:
+      sm:
+        resources:
+          limits:
+            cpu: 250m
+            memory: 500Mi
+          requests:
+            cpu: 250m
+            memory: 500Mi
+        memoryOption: 500Mi
+      te:
+        resources:
+          limits:
+            cpu: 250m
+            memory: 500Mi
+          requests:
+            cpu: 250m
+            memory: 500Mi
+        memoryOption: 500Mi

--- a/ui-test/advanced/network-failures.spec.ts
+++ b/ui-test/advanced/network-failures.spec.ts
@@ -1,0 +1,178 @@
+// (C) Copyright 2026 Dassault Systemes SE.  All Rights Reserved.
+// Converted from: selenium-tests/…/basic/UserTest.java
+/// <reference types="node" />
+import { test } from "../fixtures";
+import {
+  clickMenu,
+  retry,
+  sleep,
+  waitRestComplete,
+  waitTableElements,
+} from "../helpers/ui";
+import {
+  createUserRest,
+  deleteResourceRest,
+  TEST_ADMIN_PASSWORD,
+  TEST_ADMIN_USER,
+  TEST_ORGANIZATION,
+} from "../helpers/api";
+import { expect } from "@playwright/test";
+import net from "net";
+
+const tcpConnections = new Set<net.Socket>();
+
+/**
+ * Starts a TCP forwarder that listens on `sourcePort` and forwards all traffic
+ * to `targetPort`.
+ * This is used to simulate a temporary disconnect to the control plane
+ *
+ * @param sourcePort - Port on which the forwarder will listen.
+ * @param targetPort - Destination port to which traffic will be piped.
+ * @returns A promise that resolves with the `net.Server` instance once it is listening.
+ */
+export async function startTcpForwarder(
+  sourceHost: string,
+  sourcePort: number,
+  targetHost: string,
+  targetPort: number,
+): Promise<net.Server> {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer((clientSocket) => {
+      // When a client connects, open a connection to the target.
+      const targetSocket = net.connect(targetPort, targetHost);
+      tcpConnections.add(clientSocket);
+
+      // Pipe data both ways.
+      clientSocket.pipe(targetSocket);
+      targetSocket.pipe(clientSocket);
+
+      // If either side ends, close the other side.
+      clientSocket.on("close", () => targetSocket.end());
+      targetSocket.on("close", () => clientSocket.end());
+
+      // Propagate errors (they will also cause the server to close the socket).
+      clientSocket.on("error", (err) => console.error("Client socket error:", err));
+      targetSocket.on("error", (err) => console.error("Target socket error:", err));
+    });
+
+    server.on("error", (err) => reject(err));
+
+    // Start listening.
+    server.listen(sourcePort, sourceHost, () => {
+      console.info(`TCP forwarder listening on ${sourcePort} → ${targetPort}`);
+      resolve(server);
+    });
+  });
+}
+
+/**
+ * Stops a TCP forwarder created by `startTcpForwarder`.
+ *
+ * @param server - The `net.Server` instance returned from `startTcpForwarder`.
+ * @returns A promise that resolves when the server has fully closed.
+ */
+export async function stopTcpForwarder(server: net.Server): Promise<void> {
+  return new Promise((resolve, reject) => {
+    for (const socket of tcpConnections) {
+      socket.destroy(); // Hard reset the connection
+    }
+    tcpConnections.clear();
+    server.close((err) => {
+      if (err) {
+        console.error("Error while stopping TCP forwarder:", err);
+        reject(err);
+      } else {
+        console.info("TCP forwarder stopped");
+        resolve();
+      }
+    });
+  });
+}
+
+test.describe("UserTest", () => {
+  test("SSE network outage", async ({ restPage: page }) => {
+    let server = await startTcpForwarder("localhost", 8089, "localhost", 80);
+
+    // create user
+    let userName = await createUserRest();
+
+    // Login (using the TCP forwarder port)
+    await page.goto("http://localhost:8089/ui/login");
+    const showLoginBtn = page.getByTestId("show_login_button");
+    await showLoginBtn.waitFor({ state: "visible" });
+    await showLoginBtn.click();
+    await page.getByTestId("organization").locator("input").fill(TEST_ORGANIZATION);
+    await page.getByTestId("username").locator("input").fill(TEST_ADMIN_USER);
+    await page.getByTestId("password").locator("input").fill(TEST_ADMIN_PASSWORD);
+    await page.getByTestId("login_button").click();
+    await page.waitForURL(/\/ui(?!\/login)/);
+
+    // verify user exists
+    await clickMenu(page, "users");
+    let cells = await waitTableElements(
+      page,
+      "list_resource__table",
+      "name",
+      userName,
+      "$ref",
+    );
+    expect(cells.length).toBe(1);
+
+    // delete the user
+    deleteResourceRest("users", "integrationtest/" + userName);
+
+    // verify user no longer shows in UI (due to SSE update)
+    cells = await waitTableElements(
+      page,
+      "list_resource__table",
+      "name",
+      userName,
+      "$ref",
+    );
+    expect(cells.length).toBe(0);
+
+    // create another user and verify user shows up in the UI
+    userName = await createUserRest();
+
+    // reload user view until new user appears
+    await retry(async ()=>{
+      await clickMenu(page, "projects");
+      await waitRestComplete(page);
+      await clickMenu(page, "users");
+      await waitRestComplete(page);
+      cells = await waitTableElements(
+        page,
+        "list_resource__table",
+        "name",
+        userName,
+        "$ref",
+      );
+      expect(cells.length).toBe(1);
+    });
+
+    // simulate temporary network outage (will disconnect the existing SSE connection)
+    await stopTcpForwarder(server);
+
+    // delete USER (using REST service)
+    deleteResourceRest("users", TEST_ORGANIZATION + "/" + userName);
+
+    // restart TCP tunnel
+    server = await startTcpForwarder("localhost", 8089, "localhost", 80);
+
+    // wait until the user shows as deleted in the UI (SSE should reconnect)
+    await retry(async ()=> {
+      cells = await waitTableElements(
+        page,
+        "list_resource__table",
+        "name",
+        userName,
+        "$ref",
+      );
+      expect(cells.length).toBe(0);
+    }, 3);
+
+    // shut down TCP server and set UI back to default host
+    await page.goto("http://localhost/ui/");
+    await stopTcpForwarder(server);
+  });
+});

--- a/ui-test/advanced/network-failures.spec.ts
+++ b/ui-test/advanced/network-failures.spec.ts
@@ -16,7 +16,7 @@ import {
   TEST_ADMIN_USER,
   TEST_ORGANIZATION,
 } from "../helpers/api";
-import { expect } from "@playwright/test";
+import { expect, Locator } from "@playwright/test";
 import net from "net";
 
 const tcpConnections = new Set<net.Socket>();
@@ -109,14 +109,17 @@ test.describe("UserTest", () => {
 
     // verify user exists
     await clickMenu(page, "users");
-    let cells = await waitTableElements(
-      page,
-      "list_resource__table",
-      "name",
-      userName,
-      "$ref",
-    );
-    expect(cells.length).toBe(1);
+    let cells: Locator[];
+    await retry(async ()=>{
+      cells = await waitTableElements(
+        page,
+        "list_resource__table",
+        "name",
+        userName,
+        "$ref",
+      );
+      expect(cells.length).toBe(1);
+    });
 
     // delete the user
     deleteResourceRest("users", "integrationtest/" + userName);

--- a/ui-test/advanced/network-failures.spec.ts
+++ b/ui-test/advanced/network-failures.spec.ts
@@ -125,6 +125,7 @@ test.describe("UserTest", () => {
     deleteResourceRest("users", "integrationtest/" + userName);
 
     // verify user no longer shows in UI (due to SSE update)
+    await retry(async ()=> {
     cells = await waitTableElements(
       page,
       "list_resource__table",
@@ -133,6 +134,7 @@ test.describe("UserTest", () => {
       "$ref",
     );
     expect(cells.length).toBe(0);
+    });
 
     // create another user and verify user shows up in the UI
     userName = await createUserRest();

--- a/ui-test/advanced/sql.spec.ts
+++ b/ui-test/advanced/sql.spec.ts
@@ -37,43 +37,6 @@ const DB_READY_TIMEOUT =
 let projectName: string | null = null;
 let databaseName: string | null = null;
 
-/** Waits until the "keepdb1" database is "Available". */
-async function ensureDbAvailable(page: Page): Promise<void> {
-  if (projectName !== null && databaseName !== null) return;
-
-  test.setTimeout(185_000);
-
-  projectName = await getOrCreateProject(KEEP_PROJECT);
-  databaseName = await getOrCreateDatabase(KEEP_PROJECT, KEEP_DATABASE);
-
-  const deadline = Date.now() + DB_READY_TIMEOUT;
-  while (Date.now() < deadline) {
-    try {
-      const data = await restApi(
-        "GET",
-        `/databases/${TEST_ORGANIZATION}/${projectName}/${databaseName}`,
-      );
-      if (data?.status?.state === "Available") break;
-    } catch {
-      /* keep waiting */
-    }
-    await new Promise((r) => setTimeout(r, 1_000));
-  }
-
-  // Confirm via UI
-  await clickMenu(page, "projects");
-  await clickMenu(page, "databases");
-  const statusCols = await waitTableElements(
-    page,
-    "list_resource__table",
-    "name",
-    databaseName,
-    "status.state",
-  );
-  expect(statusCols.length).toBe(1);
-  expect(await statusCols[0].textContent()).toBe("Available");
-}
-
 /** Opens the SQL editor for the shared database and logs in. */
 async function loginSqlEditor(page: Page): Promise<void> {
   await clickMenu(page, "databases");
@@ -139,9 +102,6 @@ async function verifyAndDeleteDbUser(page: Page, user: string): Promise<void> {
 }
 
 test.describe("SqlTests", () => {
-  test.beforeEach(async ({ restPage: page }) => {
-    await ensureDbAvailable(page);
-  });
 
   test("testSqlPage – execute SQL, export data, verify downloaded content", async ({
     restPage: page,

--- a/ui-test/advanced/sql.spec.ts
+++ b/ui-test/advanced/sql.spec.ts
@@ -41,6 +41,8 @@ let databaseName: string | null = null;
 async function ensureDbAvailable(page: Page): Promise<void> {
   if (projectName !== null && databaseName !== null) return;
 
+  test.setTimeout(185_000);
+
   projectName = await getOrCreateProject(KEEP_PROJECT);
   databaseName = await getOrCreateDatabase(KEEP_PROJECT, KEEP_DATABASE);
 
@@ -140,10 +142,6 @@ test.describe("SqlTests", () => {
   test.beforeEach(async ({ restPage: page }) => {
     await ensureDbAvailable(page);
   });
-
-  test("allow database setup (with long timeout)", async () => {
-    test.setTimeout(185_000);
-  })
 
   test("testSqlPage – execute SQL, export data, verify downloaded content", async ({
     restPage: page,

--- a/ui-test/advanced/sql.spec.ts
+++ b/ui-test/advanced/sql.spec.ts
@@ -138,16 +138,20 @@ async function verifyAndDeleteDbUser(page: Page, user: string): Promise<void> {
 
 test.describe("SqlTests", () => {
   test.beforeEach(async ({ restPage: page }) => {
-    test.setTimeout(185_000)
     await ensureDbAvailable(page);
   });
+
+  test("allow database setup (with long timeout)", async () => {
+    test.setTimeout(185_000);
+  })
 
   test("testSqlPage – execute SQL, export data, verify downloaded content", async ({
     restPage: page,
   }) => {
     await loginSqlEditor(page);
 
-    await page.waitForLoadState('networkidle');
+    await waitRestComplete(page);
+    await sleep(1000);
 
     // Run DDL + DML + SELECT
     await page.getByTestId("query").click();
@@ -158,8 +162,6 @@ test.describe("SqlTests", () => {
     );
     await page.getByTestId("submitSql").click();
     await waitRestComplete(page);
-
-    await page.waitForLoadState('networkidle');
 
     await page.getByTestId("query").click();
     await sleep(1000); // TODO(agr22)

--- a/ui-test/helpers/global.teardown.ts
+++ b/ui-test/helpers/global.teardown.ts
@@ -35,7 +35,7 @@ test.describe('global teardown', () => {
                     const urlParts = cov.url.split("/");
                     const destFile = "target/" + urlParts[urlParts.length-1] + ".map";
                     if(!fs.existsSync(destFile)) {
-                        const res = await fetch(cov.url + ".map");
+                        const res = await fetch(cov.url.replace(":8089", "") + ".map");
                         if (res.ok) {
                             const fileStream = fs.createWriteStream(destFile, { flags: 'wx' });
                             await finished(Readable.fromWeb(res.body).pipe(fileStream));

--- a/ui-test/helpers/ui.ts
+++ b/ui-test/helpers/ui.ts
@@ -195,11 +195,16 @@ export async function replaceInputOrTextareaByName(
     return;
   }
   // Regular input
-  let input = await getInputOrTextareaByName(page, name);
-  input.waitFor({state: "visible"});
-  if(await input.inputValue() !== value) {
-    await input.fill(value);
-  }
+  await retry(async ()=> {
+    // MUI Input field is weird - it initially creates a textarea (non-visible) and then an input field or the other way around ...
+    let input = await getInputOrTextareaByName(page, name);
+    if(!await input.isVisible()) {
+      throw new Error("input/textarea field not visible"); //retry
+    }
+    if(await input.inputValue() !== value) {
+      await input.fill(value);
+    }
+  });
 }
 
 export async function replaceInputByName(

--- a/ui-test/package-lock.json
+++ b/ui-test/package-lock.json
@@ -15,7 +15,7 @@
       },
       "devDependencies": {
         "@playwright/test": "^1.58.2",
-        "@types/node": "^25.5.0"
+        "@types/node": "^25.5.2"
       }
     },
     "node_modules/@jridgewell/resolve-uri": {
@@ -66,9 +66,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.5.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.0.tgz",
-      "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
+      "version": "25.5.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.2.tgz",
+      "integrity": "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/ui-test/package.json
+++ b/ui-test/package.json
@@ -35,7 +35,7 @@
   "homepage": "/",
   "devDependencies": {
     "@playwright/test": "^1.58.2",
-    "@types/node": "^25.5.0"
+    "@types/node": "^25.5.2"
   },
   "nyc": {
     "extension": [

--- a/ui-test/playwright.config.ts
+++ b/ui-test/playwright.config.ts
@@ -16,7 +16,7 @@ export default defineConfig({
   /* Retry on CI only */
   retries: process.env.CI ? 2 : 0,
   /* Reporter to use */
-  reporter: [['html', { outputFolder: 'target/playwright-report' }]],
+  reporter: [['list'],['html', { outputFolder: 'target/playwright-report' }]],
   use: {
     /* Base URL */
     baseURL: "http://localhost",

--- a/ui/src/components/pages/ListResource.tsx
+++ b/ui/src/components/pages/ListResource.tsx
@@ -86,7 +86,7 @@ function ListResource(props: PageProps) {
                     }, (error: TempAny) => {
                         Auth.handle401Error(error);
                         setItemsAndPath({ items: [], path });
-                    })
+                    }, 1000)
                 );
             }).catch((reason) => {
                 Toast.show("Unable to get resource in " + path, reason);

--- a/ui/src/components/pages/ViewResource.tsx
+++ b/ui/src/components/pages/ViewResource.tsx
@@ -1,4 +1,4 @@
-// (C) Copyright 2024-2025 Dassault Systemes SE.  All Rights Reserved.
+// (C) Copyright 2024-2026 Dassault Systemes SE.  All Rights Reserved.
 
 import { ReactNode, useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";

--- a/ui/src/components/pages/ViewResource.tsx
+++ b/ui/src/components/pages/ViewResource.tsx
@@ -37,7 +37,7 @@ function ViewResource(props: PageProps) {
                 setError(error);
                 Auth.handle401Error(error);
                 setData({});
-            });
+            }, 1000);
         }
         else {
             setData({});

--- a/ui/src/utils/schema.ts
+++ b/ui/src/utils/schema.ts
@@ -363,7 +363,7 @@ let lastSetTimeout_getResourceEvents: any = undefined;
  * @param {*} retryIntervalMS - milliseconds for the next retry (which will be doubled each time). Set to <= 0 to disable retries.
  * @returns AbortController - use ret.abort() to abort
  */
-export function getResourceEvents(schema: any, path: string, multiResolve: TempAny, multiReject: TempAny, retryIntervalMS: number = 0) : void {
+export function getResourceEvents(schema: any, path: string, multiResolve: TempAny, multiReject: TempAny, retryIntervalMS: number = 0) {
     if(lastSetTimeout_getResourceEvents) {
         clearTimeout(lastSetTimeout_getResourceEvents);
     }
@@ -517,6 +517,8 @@ export function getResourceEvents(schema: any, path: string, multiResolve: TempA
       .finally(()=>{
         monitoredPaths.delete(path.split("?")[0]);
       });
+
+      return eventsAbortController;
 }
 
 /**

--- a/ui/src/utils/schema.ts
+++ b/ui/src/utils/schema.ts
@@ -353,14 +353,20 @@ export function hasMonitoredPath(path: string) : boolean {
     return monitoredPaths.has(path.split("?")[0]);
 }
 
+let lastSetTimeout_getResourceEvents: any = undefined;
+
 /**
  * Gets event streaming resource by path (fall back to non-streaming resource on failure)
  * @param {*} path
  * @param {*} multiResolve - returns response
  * @param {*} multiReject - returns error
+ * @param {*} retryIntervalMS - milliseconds for the next retry (which will be doubled each time). Set to <= 0 to disable retries.
  * @returns AbortController - use ret.abort() to abort
  */
-export function getResourceEvents(schema: any, path: string, multiResolve: TempAny, multiReject: TempAny) {
+export function getResourceEvents(schema: any, path: string, multiResolve: TempAny, multiReject: TempAny, retryIntervalMS: number = 0) : void {
+    if(lastSetTimeout_getResourceEvents) {
+        clearTimeout(lastSetTimeout_getResourceEvents);
+    }
     //only one event stream is supported - close prior one if it exists.
     let eventsAbortController = new AbortController();
 
@@ -498,18 +504,19 @@ export function getResourceEvents(schema: any, path: string, multiResolve: TempA
                 .then(data => multiResolve(data))
                 .catch(reason => multiReject(reason));
         }
-        else if(error.status) {
-            Toast.show("Cannot retrieve resource for path " + path, error.status + " " + error.message);
-        }
         else {
-            //request was aborted. Ignore.
+            // request failed. Retry incrementally.
+            if(retryIntervalMS > 0) {
+                // reconnect - server/proxy might disconnect due to a timeout
+                lastSetTimeout_getResourceEvents = setTimeout(()=> {
+                    getResourceEvents(schema, path, multiResolve, multiReject, retryIntervalMS * 1.3); //retry with a 30% delay (exponential backoff)
+                }, retryIntervalMS);
+            }
         }
       })
       .finally(()=>{
         monitoredPaths.delete(path.split("?")[0]);
       });
-
-      return eventsAbortController;
 }
 
 /**


### PR DESCRIPTION
if SSE connections are dropped, re-connect (with incremental wait time of 30%)

Additional changes:
- use ECR nuodb and nuodb-collector docker image if AWS environment variables are configured
- fix flaky tests due to MUI input/textarea control refresh issues
- add "list" reporter, so the CI output doesn't seem to hang (will write each test being processed)
- added network dropout simulation tests by adding a man-in-the-middle service to be able to disconnect the network