### PR TITLE
show all controls if Control Plane doesn't provide any accessRule.allow entries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -302,8 +302,6 @@ setup-nginx-default-conf:
 
 .PHONY: setup-integration-tests
 setup-integration-tests: $(KUBECTL) setup-nginx-default-conf install-crds deploy-monitoring deploy-cp deploy-operator deploy-sql deploy-keycloak deploy-cas-server deploy-webui ## setup containers before running integration tests
-	@npx playwright install || true
-
 	@$(KUBECTL) exec -n default -it $(shell ${KUBECTL} get pod -n default -l "app=nuodb-cp-rest" -o name) -- bash -c "curl \
 		http://localhost:8080/users/acme/admin?allowCrossOrganizationAccess=true \
 		--data-binary \
@@ -331,7 +329,8 @@ teardown-integration-tests: $(KIND) undeploy-sql undeploy-webui undeploy-seleniu
 
 .PHONY: run-integration-tests-only
 run-integration-tests-only: ## integration tests without setup/teardown
-	@cd ui-test && npm install && npm run e2e -- --workers 1 && cd ..
+	@cd ui && npm install && cd ..
+	@cd ui-test && npm install && npx playwright install && npm run e2e -- --workers 1 && cd ..
 
 .PHONY: run-unit-tests
 run-unit-tests: ## run unit tests

--- a/ui/src/utils/auth.ts
+++ b/ui/src/utils/auth.ts
@@ -183,9 +183,17 @@ export default class Auth {
         }
     }
 
-    static getAccessRule() : {allow:[allow:string],deny:[deny:string]} {
+    static getAccessRule() : {allow:string[], deny:string[]} {
         const credentials = JSON.parse(localStorage.getItem("credentials") || "{}");
         const accessRule = credentials.accessRule || {};
-        return {allow: accessRule.allow || ["all:*"], deny: accessRule.deny || []};
+        let allow = accessRule.allow || ["all:*"];
+        if(allow.length === 0) {
+            // There should be at least one allow rule but there is none provided.
+            // As a fallback, enable the UI to show all resources, so the UI is at least functional.
+            // It may show additional buttons in the UI, but the Control Plane REST service will prevent
+            // operations if the user doesn't have access.
+            allow = ["all:*", ""];
+        }
+        return {allow, deny: accessRule.deny || []};
     }
 }


### PR DESCRIPTION
this is a fallback to show all UI controls if the Control Plane doesn't provide any `accessRule.allow` entries during the login process. This is currently exposed when logging in to a 3rd party identify provider.