### PR TITLE
Allow environment specific customizations using a helm value

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -295,7 +295,12 @@ deploy-webui: $(HELM) $(KIND)  ## deploy WebUI
 	@if [ -d charts/nuodbaas-webui ] ; then \
 		${MAKE} build-image && \
 		$(KIND) load docker-image nuodbaas-webui:latest && \
-		$(HELM) upgrade --install --wait -n default nuodbaas-webui charts/nuodbaas-webui --set image.repository=nuodbaas-webui --set image.tag=latest --set nuodbaasWebui.ingress.enabled=true --set nuodbaasWebui.cpUrl=/api; \
+		$(HELM) upgrade --install --wait -n default nuodbaas-webui charts/nuodbaas-webui \
+			--set image.repository=nuodbaas-webui \
+			--set image.tag=latest \
+			--set-file nuodbaasWebui.customJson=docker/development/custom.json \
+			--set nuodbaasWebui.ingress.enabled=true \
+			--set nuodbaasWebui.cpUrl=/api; \
 	fi
 
 .PHONY: undeploy-webui
@@ -385,7 +390,10 @@ run-integration-tests: build-image setup-integration-tests ## run integration te
 .PHONY: start-dev
 start-dev: stop-dev setup-integration-tests ## launch WebUI/ControlPlane/Proxy for development environment
 	(cd ui && npm install && npm start &)
-	docker run --rm -d --name nuodb-webui-dev -v `pwd`/docker/development/default.conf:/etc/nginx/conf.d/default.conf --network=host -it nginx:stable-alpine
+	docker run --rm -d --name nuodb-webui-dev \
+		-v `pwd`/docker/development/default.conf:/etc/nginx/conf.d/default.conf \
+		-v `pwd`/docker/development/custom.json:/usr/share/nginx/html/theme/custom.json \
+		--network=host -it nginx:stable-alpine
 
 .PHONY: start-dev-remote
 start-dev-remote: setup-nginx-default-conf ## launch WebUI to remote Control Plane. Set environment variables NUODB_CP_URL_BASE and NUODB_SQL_URL_BASE

--- a/Makefile
+++ b/Makefile
@@ -298,7 +298,7 @@ deploy-webui: $(HELM) $(KIND)  ## deploy WebUI
 		$(HELM) upgrade --install --wait -n default nuodbaas-webui charts/nuodbaas-webui \
 			--set image.repository=nuodbaas-webui \
 			--set image.tag=latest \
-			--set-file nuodbaasWebui.customJson=docker/development/custom.json \
+			--set-file nuodbaasWebui.customConfig=docker/development/custom.json \
 			--set nuodbaasWebui.ingress.enabled=true \
 			--set nuodbaasWebui.cpUrl=/api; \
 	fi

--- a/build_utils.sh
+++ b/build_utils.sh
@@ -198,7 +198,7 @@ if [ "$1" == "createProjectAndDatabase" ] ; then
         exit 1
     fi
 	./bin/kubectl exec -n default -it ${CP_POD} -- nuodb-cp project create integrationtest/keepproject --sla=dev --tier=n0.nano || true
-	./bin/kubectl exec -n default -it ${CP_POD} -- nuodb-cp database create integrationtest/keepproject/keepdb1 --dba-password=passw0rd || true
+	./bin/kubectl exec -n default -it ${CP_POD} -- nuodb-cp database create --label ds.com/abc=abc integrationtest/keepproject/keepdb1 --dba-password=passw0rd || true
     for i in {1..36}; do
         STATE=$(./bin/kubectl exec -n default -it ${CP_POD} -- nuodb-cp database get integrationtest/keepproject/keepdb1 | grep -e "\"state\"") || true
         AVAILABLE=$(echo "$STATE" | grep -e "Available") || true

--- a/charts/nuodbaas-webui/README.md
+++ b/charts/nuodbaas-webui/README.md
@@ -33,6 +33,7 @@ All configurable parameters for each top-level scope are detailed below, organiz
 | `nuodbaasWebui.ephemeralVolume.enabled` |  Whether to create a generic ephemeral volume rather than emptyDir for any storage that does not outlive the pod | `false` |
 | `nuodbaasWebui.ephemeralVolume.size` |  The size of the generic ephemeral volume to create | `1Gi` |
 | `nuodbaasWebui.ephemeralVolume.storageClass` |  The storage class to use for the generic ephemeral volume | `""` |
+| `nuodbaasWebui.customConfig` | JSON value with UI customizations. Details here: https://github.com/nuodb/nuodbaas-webui/blob/main/ui/customizations.md | `{}` |
 
 ## Uninstalling the Chart
 

--- a/charts/nuodbaas-webui/templates/custom-config-configmap.yaml
+++ b/charts/nuodbaas-webui/templates/custom-config-configmap.yaml
@@ -3,10 +3,10 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "nuodbaas-webui.fullname" . }}-custom-json
+  name: {{ include "nuodbaas-webui.fullname" . }}-custom-config
   labels:
     {{- include "nuodbaas-webui.labels" . | nindent 4 }}
 
 data:
   custom.json: |
-{{ .Values.nuodbaasWebui.customJson | indent 4 }}
+{{ .Values.nuodbaasWebui.customConfig | indent 4 }}

--- a/charts/nuodbaas-webui/templates/custom-json-configmap.yaml
+++ b/charts/nuodbaas-webui/templates/custom-json-configmap.yaml
@@ -1,0 +1,12 @@
+# (C) Copyright 2024-2026 Dassault Systemes SE.  All Rights Reserved.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "nuodbaas-webui.fullname" . }}-custom-json
+  labels:
+    {{- include "nuodbaas-webui.labels" . | nindent 4 }}
+
+data:
+  custom.json: |
+{{ .Values.nuodbaasWebui.customJson | indent 4 }}

--- a/charts/nuodbaas-webui/templates/custom-json-configmap.yaml
+++ b/charts/nuodbaas-webui/templates/custom-json-configmap.yaml
@@ -1,4 +1,4 @@
-# (C) Copyright 2024-2026 Dassault Systemes SE.  All Rights Reserved.
+# (C) Copyright 2026 Dassault Systemes SE.  All Rights Reserved.
 
 apiVersion: v1
 kind: ConfigMap

--- a/charts/nuodbaas-webui/templates/deployment.yaml
+++ b/charts/nuodbaas-webui/templates/deployment.yaml
@@ -65,6 +65,10 @@ spec:
           volumeMounts:
           - name: tmp-volume
             mountPath: /tmp
+          - name: custom-json-volume
+            mountPath: /usr/share/nginx/html/theme/custom.json
+            subPath: custom.json
+            readOnly: true
       {{- with .Values.nuodbaasWebui.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -84,3 +88,6 @@ spec:
       volumes:
       - name: tmp-volume
         {{- include "nuodbaas-webui.ephemeralVolume" . | indent 8 }}
+      - name: custom-json-volume
+        configMap:
+          name: {{ include "nuodbaas-webui.fullname" . }}-custom-json

--- a/charts/nuodbaas-webui/templates/deployment.yaml
+++ b/charts/nuodbaas-webui/templates/deployment.yaml
@@ -65,7 +65,7 @@ spec:
           volumeMounts:
           - name: tmp-volume
             mountPath: /tmp
-          - name: custom-json-volume
+          - name: custom-config-volume
             mountPath: /usr/share/nginx/html/theme/custom.json
             subPath: custom.json
             readOnly: true
@@ -88,6 +88,6 @@ spec:
       volumes:
       - name: tmp-volume
         {{- include "nuodbaas-webui.ephemeralVolume" . | indent 8 }}
-      - name: custom-json-volume
+      - name: custom-config-volume
         configMap:
-          name: {{ include "nuodbaas-webui.fullname" . }}-custom-json
+          name: {{ include "nuodbaas-webui.fullname" . }}-custom-config

--- a/charts/nuodbaas-webui/values.yaml
+++ b/charts/nuodbaas-webui/values.yaml
@@ -139,3 +139,8 @@ nuodbaasWebui:
 
     # The storage class to use for the generic ephemeral volume.
     storageClass: ""
+
+  # JSON content for custom.json. Use a multi-line string.
+  customJson: |
+    {
+    }

--- a/charts/nuodbaas-webui/values.yaml
+++ b/charts/nuodbaas-webui/values.yaml
@@ -141,6 +141,7 @@ nuodbaasWebui:
     storageClass: ""
 
   # JSON content for custom.json. Use a multi-line string.
-  customJson: |
+  # Info on the format is described in https://github.com/nuodb/nuodbaas-webui/blob/main/ui/customizations.md
+  customConfig: |
     {
     }

--- a/copyright_ignore.txt
+++ b/copyright_ignore.txt
@@ -13,6 +13,7 @@
 ^\./selenium-tests/package-lock.json$
 ^\./selenium-tests/package.json$
 ^\./selenium-tests/keycloak/keycloak-protocol-cas-26.2.1.jar
+^\./docker/development/default.conf$
 ^\./ui/package-lock.json$
 \.md$
 \./ui/public/favicon.ico$

--- a/docker/development/custom.json
+++ b/docker/development/custom.json
@@ -1,0 +1,14 @@
+{
+    "views": {
+        "/databases": {
+            "menu-append": [
+                {
+                    "label": "ConnectionInfoCustom",
+                    "icon": "Info",
+                    "link": "https://www.example.com/{organization}/{project}/{name}/{tier}",
+                    "linkTarget": "_blank"
+                }
+            ]
+        }
+    }
+}

--- a/docker/development/custom.json
+++ b/docker/development/custom.json
@@ -1,11 +1,29 @@
 {
+    "copyright": "(C) Copyright 2026 Dassault Systemes SE.  All Rights Reserved.",
     "views": {
         "/databases": {
+            "columns": [
+                "name",
+                "organization",
+                "project",
+                "labels",
+                "tier",
+                "labels.ds.com/abc",
+                "properties",
+                "status.state",
+                "status"
+            ],
+            "links": {
+                "labels.ds.com/abc": {
+                    "link": "https://www.example.com/{labels.ds.com/abc}",
+                    "linkTarget": "_blank"
+                }
+            },
             "menu-append": [
                 {
-                    "label": "ConnectionInfoCustom",
+                    "label": "ExternalUrl",
                     "icon": "Info",
-                    "link": "https://www.example.com/{organization}/{project}/{name}/{tier}",
+                    "link": "https://www.example.com/{organization}/{project}/{name}/{tier}/{labels.ds.com/abc}",
                     "linkTarget": "_blank"
                 }
             ]

--- a/docker/development/default.conf.template
+++ b/docker/development/default.conf.template
@@ -1,4 +1,4 @@
-# (C) Copyright 2024-2025 Dassault Systemes SE.  All Rights Reserved.
+# (C) Copyright 2024-2026 Dassault Systemes SE.  All Rights Reserved.
 
 server {
   listen 81;

--- a/docker/development/default.conf.template
+++ b/docker/development/default.conf.template
@@ -9,6 +9,10 @@ server {
     proxy_pass http://localhost:3000/ui/;
   }
 
+  location /ui/theme/custom.json {
+    alias /usr/share/nginx/html/theme/custom.json;
+  }
+
   location /nuodb-cp/ {
     proxy_pass %%%NUODB_CP_URL_BASE%%%/;
   }

--- a/docker/production/files/entrypoint.sh
+++ b/docker/production/files/entrypoint.sh
@@ -9,13 +9,13 @@ if [ "$1" == "tgz_static" ] ; then
 fi
 
 if [ "${NUODB_CP_REST_URL}" != "" ] ; then
-    find /usr/share/nginx/html -type f ! -name "config.json" | while read line; do
+    find /usr/share/nginx/html -type f ! -name "custom.json" | while read line; do
         sed -i "s#___NUODB_CP_REST_URL___#${NUODB_CP_REST_URL}#g" ${line}
     done
 fi
 
 if [ "${NUODB_SQL_REST_URL}" != "" ] ; then
-    find /usr/share/nginx/html -type f ! -name "config.json" | while read line; do
+    find /usr/share/nginx/html -type f ! -name "custom.json" | while read line; do
         sed -i "s#___NUODB_SQL_REST_URL___#${NUODB_SQL_REST_URL}#g" ${line}
     done
 fi

--- a/docker/production/files/entrypoint.sh
+++ b/docker/production/files/entrypoint.sh
@@ -9,15 +9,19 @@ if [ "$1" == "tgz_static" ] ; then
 fi
 
 if [ "${NUODB_CP_REST_URL}" != "" ] ; then
-    find /usr/share/nginx/html -type f | while read line; do
+    find /usr/share/nginx/html -type f ! -name "config.json" | while read line; do
         sed -i "s#___NUODB_CP_REST_URL___#${NUODB_CP_REST_URL}#g" ${line}
     done
 fi
 
 if [ "${NUODB_SQL_REST_URL}" != "" ] ; then
-    find /usr/share/nginx/html -type f | while read line; do
+    find /usr/share/nginx/html -type f ! -name "config.json" | while read line; do
         sed -i "s#___NUODB_SQL_REST_URL___#${NUODB_SQL_REST_URL}#g" ${line}
     done
+fi
+
+if [ -f /usr/share/nginx/html/theme/custom.json ] ; then
+    cp /usr/share/nginx/html/theme/custom.json /usr/share/nginx/html/ui/theme/custom.json
 fi
 
 if [ "${NUODBAAS_WEBUI_PATH_PREFIX}" != "" ] ; then

--- a/ui-test/basic/database.spec.ts
+++ b/ui-test/basic/database.spec.ts
@@ -270,6 +270,20 @@ test.describe("DatabaseTest", () => {
     await page.getByTestId("copy-Database").click();
     await page.getByTestId("dialog_button_ok").click();
 
+    // Popup menu: ConnectionInfoCustom (custom menu item)
+    await page.getByTestId("resource-popup-menu").click();
+    await page.getByTestId("popupmenu-ConnectionInfoCustom").click();
+    const expectedURL = 'https://www.example.com/integrationtest/' + projectName + '/' + databaseName + '/n0.nano';
+    await expect(page).toHaveURL(expectedURL);
+
+    // validate we are on a new "_blank" page by trying to go back and making sure we are still on the same URL
+    await page.goBack();
+    await expect(page).toHaveURL(expectedURL);
+
+    // close new _blank tab
+    await page.close();
+
+
     // Popup menu: Stop → No
     await page.getByTestId("resource-popup-menu").click();
     await page.getByTestId("popupmenu-confirm.stop.database.title").click();

--- a/ui-test/basic/database.spec.ts
+++ b/ui-test/basic/database.spec.ts
@@ -218,7 +218,9 @@ test.describe("DatabaseTest", () => {
     restPage: page,
   }) => {
     const projectName = await createProjectRest();
-    const databaseName = await createDatabaseRest(projectName);
+    const databaseName = await createDatabaseRest(projectName, undefined, {
+      "ds.com/abc": "abc",
+    });
     waitRestComplete(page);
 
     await clickMenu(page, "databases");
@@ -270,20 +272,6 @@ test.describe("DatabaseTest", () => {
     await page.getByTestId("copy-Database").click();
     await page.getByTestId("dialog_button_ok").click();
 
-    // Popup menu: ConnectionInfoCustom (custom menu item)
-    await page.getByTestId("resource-popup-menu").click();
-    await page.getByTestId("popupmenu-ConnectionInfoCustom").click();
-    const expectedURL = 'https://www.example.com/integrationtest/' + projectName + '/' + databaseName + '/n0.nano';
-    await expect(page).toHaveURL(expectedURL);
-
-    // validate we are on a new "_blank" page by trying to go back and making sure we are still on the same URL
-    await page.goBack();
-    await expect(page).toHaveURL(expectedURL);
-
-    // close new _blank tab
-    await page.close();
-
-
     // Popup menu: Stop → No
     await page.getByTestId("resource-popup-menu").click();
     await page.getByTestId("popupmenu-confirm.stop.database.title").click();
@@ -295,5 +283,49 @@ test.describe("DatabaseTest", () => {
       .getByTestId("popupmenu-button.sql.editor")
       .waitFor({ state: "visible" });
     await page.keyboard.press("Escape");
+
+    // Popup menu: ExternalUrl (custom menu item)
+    await page.getByTestId("resource-popup-menu").click();
+    const [newTab] = await Promise.all([
+      page.waitForEvent("popup"),
+      page.getByTestId("popupmenu-ExternalUrl").click(),
+    ]);
+    let expectedURL =
+      "https://www.example.com/integrationtest/" +
+      projectName +
+      "/" +
+      databaseName +
+      "/n0.nano/abc";
+    await expect(newTab).toHaveURL(expectedURL);
+
+    // validate we are on a new "_blank" page by trying to go back and making sure we are still on the same URL
+    await newTab.goBack();
+    await expect(newTab).toHaveURL(expectedURL);
+
+    // close new _blank tab
+    await newTab.close();
+
+    // Custom Link: labels.ds.com/abc
+    await clickMenu(page, "databases");
+    const labelCell = await waitTableElements(
+      page,
+      "list_resource__table",
+      "name",
+      databaseName,
+      "labels.ds.com/abc",
+    );
+    const [newTab2] = await Promise.all([
+      page.waitForEvent("popup"),
+      labelCell[0].getByRole("button").click(),
+    ]);
+    expectedURL = "https://www.example.com/abc";
+    await expect(newTab2).toHaveURL(expectedURL);
+
+    // validate we are on a new "_blank" page by trying to go back and making sure we are still on the same URL
+    await newTab2.goBack();
+    await expect(newTab2).toHaveURL(expectedURL);
+
+    // close new _blank tab
+    await newTab2.close();
   });
 });

--- a/ui-test/helpers/api.ts
+++ b/ui-test/helpers/api.ts
@@ -207,6 +207,7 @@ export async function createProjectRest(name?: string): Promise<string> {
 export async function createDatabaseRest(
   projectName: string,
   name?: string,
+  labels?: any,
 ): Promise<string> {
   const n = name ?? shortUnique("d");
   await createResourceRest(
@@ -217,6 +218,7 @@ export async function createDatabaseRest(
       project: projectName,
       name: n,
       dbaPassword: "passw0rd",
+      labels: labels,
     },
   );
   return n;

--- a/ui/customizations.md
+++ b/ui/customizations.md
@@ -1,97 +1,735 @@
 # NuoDBaaS WebUI customizations
 
-The NuoDBaaS WebUI allows for UI customizations to handle special cases which are not defined in the OpenAPI spec file. These are currently action buttons in the views and in the future will be extended to simplified forms.
-The configuration file is currently stored in `public/theme/base.json` and `public/theme/<theme>.json` and is a JSON file containing configurations, macros ("value" and "disabled" attributes). There are also corresponding `css` files in the same location.
+The NuoDBaaS WebUI supports JSON-based customizations that are merged at startup and then used to alter list views, row action menus, forms, and theme-related settings.
 
-## Example configuration file
+Customization data is loaded from the following sources, in this order:
 
-```
-function getCustomizations() {
-    return {
-    "views": {
-        "/databases": {
-            status: {
-                value: "status.ready",
-                buttons: [
-                    {
-                        "label": "Start Database",
-                        "patch": [
-                            {
-                                "op": "remove",
-                                "path": "/maintenance"
-                            }
-                        ],
-                        "visible": "maintenance",
-                        "confirm": "Do you want to start Database {organization}/{project}/{name}?",
-                    },
-                ]
-            }
-        },
-        "/backuppolicies": {
-            "show": {
-                buttons: [
-                    {
-                        "label": "Show Databases",
-                        "link": "/ui/resource/list/backuppolicies/{organization}/{name}/databases"
-                    }
-                ]
-            }
-        },
+1. `ui/public/theme/base.json`
+2. `ui/public/theme/custom.json`
+3. user settings stored in browser local storage under `nuodbaas_webui_userSettings`
+
+Later sources override earlier ones. Object values are merged recursively. Arrays are replaced by default, but can also be appended to by using a key with the `-append` suffix, for example `menu-append` or `columns-append`.
+
+## Where customizations are used
+
+Customizations are consumed from `ui/src/utils/Customizations.tsx` and referenced from several UI components:
+
+- list/table views use `views.<RESOURCE_PATH>.columns`, `views.<RESOURCE_PATH>.fields`, `views.<RESOURCE_PATH>.menu`, and `views.<RESOURCE_PATH>.links`
+- create/edit/view forms use `forms.<RESOURCE_PATH>.sections`
+- CSS and other theme settings are loaded from `theme`
+- user-specific column selections are persisted back into local storage and merged into the active customization set
+
+## Merge behavior
+
+The merge logic is implemented in `mergeRecursive()`.
+
+- objects are merged recursively
+- scalar values replace previous values
+- arrays replace previous arrays by default
+- arrays can be appended to by using a sibling key ending in `-append`
+
+Examples:
+
+### Override an existing array
+
+```json
+{
+  "views": {
+    "/databases": {
+      "columns": ["name", "organization", "project", "status"]
     }
-}
+  }
 }
 ```
 
-### Configuration file definition
+This replaces the full `columns` array inherited from `base.json`.
 
-```
-function getCustomizations() {
-    return {
-    "views": {
-        "RESOURCE_PATH": {
-            COLUMH_FIELDNAME: {
-                value: (DATA_CONTAINING_ROW_VALUES) => CALLBACK_TO_CALCULATE_COLUMN_VALUE,
-                buttons: [
-                    {
-                        "label": BUTTON_LABEL,
-                        "patch": PATCH_BODY,
-                        "visible": (DATA_CONTAINING_ROW_VALUES) => CALLBACK_TO_DETERMINE_IF_BUTTON_IS_VISIBLE,
-                        "confirm": CONFIRM_DIALOG_TEXT,
-                    },
-                ]
-            }
-        },
-        "RESOURCE_PATH": {
-            COLUMN_FIELDNAME: {
-                buttons: [
-                    {
-                        "label": BUTTON_LABEL,
-                        "link": REDIRECT_LINK_WHEN_BUTTON_IS_PRESSED
-                    }
-                ]
-            }
-        },
+### Append to an existing array
+
+```json
+{
+  "views": {
+    "/databases": {
+      "columns-append": ["labels", "tier"]
     }
-}
+  }
 }
 ```
 
-### Explanation of configuration file definition
+This keeps the inherited columns and appends `labels` and `tier`.
 
-The NuoDBaaS WebUI will include the `themes/base.json` and `themes/<theme>.json` files to retrieve the customization definitions.
+### Append menu entries
 
-- The only root keyword is `views` right now defining view definitions
-- The `views` object contains a list of `RESOURCE_PATH` definition based on the Control Plane Rest API. These paths can have placeholders, i.e. `/databases/{organization}/{project}` which match with the definitions in the OpenAPI spec. All child elements below this resource path define how the view for this resource path is customized.
-- `COLUMN_FIELDNAME` are column names which should be modified in the view
-- The `value` attribute below the `COLUMN_FIELDNAME` specifies a callback to calculate the value which should be shown in the view column for that row which is passed into this callback function. This attribute is optional
-- The `buttons` attribute below the `COLUMN_FIELDNAME` contains a list of buttons to be shown in this column after the column value.
+```json
+{
+  "views": {
+    "/projects": {
+      "menu-append": [
+        {
+          "label": "button.show.databases",
+          "link": "/ui/resource/list/databases/{organization}/{name}"
+        }
+      ]
+    }
+  }
+}
+```
 
-### Buttons definition
+### Override one nested property only
 
-Each button has following attributes:
+```json
+{
+  "forms": {
+    "/databases/{organization}/{project}/{name}": {
+      "sections": [
+        {
+          "fields": {
+            "dbaPassword": {
+              "hidden": false
+            },
+            "*": {}
+          }
+        }
+      ]
+    }
+  }
+}
+```
 
-- `label`: title of the button. Can contain placeholders such as `{organization}`
-- `link`: URL path (relative or absolute) where to redirect the user to when the button is pressed. Either `link` or `patch` need to be specified.
-- `patch`: payload to send to the Control Plane REST API if the button is pressed. Either `patch` or `link` need to be specified
-- `visible` (optional): callback to determine if the button should be shown.
-- `confirm` (optional): show a confirm dialog with the provided text. Can have placeholders like `{organization}`
+## Top-level structure
+
+```json
+{
+  "theme": {
+    "css": "..."
+  },
+  "views": {
+    "RESOURCE_PATH": {
+      "columns": ["FIELD", "..."],
+      "columns-append": ["FIELD", "..."],
+      "fields": {
+        "FIELD_NAME": {
+          "label": "LABEL_OR_I18N_KEY",
+          "value": "FORMULA"
+        }
+      },
+      "menu": [
+        {
+          "label": "LABEL_OR_I18N_KEY",
+          "icon": "MUI_ICON_NAME",
+          "patch": [],
+          "writeAccessRequired": true,
+          "visible": "FORMULA",
+          "confirm": "LABEL_OR_I18N_KEY",
+          "dialog": "DIALOG_NAME",
+          "link": "/ui/...",
+          "linkTarget": "_blank"
+        }
+      ],
+      "menu-append": [
+        {
+          "label": "LABEL_OR_I18N_KEY",
+          "link": "/ui/..."
+        }
+      ],
+      "links": {
+        "FIELD_NAME": {
+          "link": "https://example.com/{name}",
+          "linkTarget": "_blank"
+        }
+      }
+    }
+  },
+  "forms": {
+    "RESOURCE_PATH": {
+      "sections": [
+        {
+          "title": "SECTION_TITLE_OR_I18N_KEY",
+          "fields": {
+            "fieldName": {
+              "required": true,
+              "expand": false,
+              "hidden": false
+            },
+            "nested.field": {
+              "hidden": true
+            },
+            "*": {}
+          }
+        }
+      ]
+    }
+  }
+}
+```
+
+## Loading and file locations
+
+Server-provided customization files are read from:
+
+- `ui/public/theme/base.json`
+- `ui/public/theme/custom.json`
+
+User-specific customizations are edited in the UI settings page and stored in browser local storage under `nuodbaas_webui_userSettings`.
+
+The `custom.json` file is intended to override or extend the defaults from `base.json`. This file can be replaced by volume-mounting the docker container at `/usr/share/nginx/html/theme/custom.json` or by setting the helm value `nuodbaasWebui.customJson` with the content of the file (i.e. by using the `--set-file` option.
+
+## `views` customizations
+
+The `views` object contains per-resource-path customizations for list and table pages.
+
+A resource path is typically an OpenAPI path such as `/databases`, `/backuppolicies`, or `/projects`. View lookup matches either the exact path or a child path starting with that path.
+
+### Supported view properties
+
+#### `columns`
+
+Defines the visible column order for a table view.
+
+Example:
+
+```json
+{
+  "views": {
+    "/backuppolicies": {
+      "columns": [
+        "name",
+        "organization",
+        "frequency",
+        "selector",
+        "retention"
+      ]
+    }
+  }
+}
+```
+
+#### `columns-append`
+
+Appends additional columns to an inherited `columns` array.
+
+Example:
+
+```json
+{
+  "views": {
+    "/backuppolicies": {
+      "columns-append": ["properties", "labels"]
+    }
+  }
+}
+```
+
+#### `fields`
+
+Overrides per-column label and/or displayed value.
+
+Supported field properties:
+
+- `label`: replacement label or i18n key for the column
+- `value`: formula evaluated against the row data
+
+Example:
+
+```json
+{
+  "views": {
+    "/databases": {
+      "fields": {
+        "status": {
+          "label": "Database state",
+          "value": "status.state"
+        }
+      }
+    }
+  }
+}
+```
+
+#### `menu`
+
+Defines row action menu entries shown in the resource popup menu.
+
+Supported menu item properties:
+
+- `label`: menu label, usually an i18n key
+- `icon` (optional): icon name rendered via the shared `Icon` component
+- `patch` (optional): JSON Patch payload sent to the REST API
+- `writeAccessRequired` (optional): requires `PUT` access in addition to any other checks
+- `visible` (optional): formula controlling whether the item is shown
+- `confirm` (optional): translation key or text shown in a confirmation dialog
+- `dialog` (optional): opens a built-in custom dialog
+- `link` (optional): navigates to a relative UI route or leaves absolute URLs untouched
+- `linkTarget` (currently typed but not used by the row action handler)
+
+A menu item should typically use one of:
+
+- `patch`
+- `link`
+- `dialog`
+
+Example using `patch`:
+
+```json
+{
+  "views": {
+    "/databases": {
+      "menu": [
+        {
+          "label": "confirm.start.database.title",
+          "icon": "PlayArrow",
+          "patch": [
+            {
+              "op": "remove",
+              "path": "/maintenance"
+            }
+          ],
+          "visible": "maintenance.isDisabled",
+          "confirm": "confirm.start.database.body"
+        }
+      ]
+    }
+  }
+}
+```
+
+Example using `link`:
+
+```json
+{
+  "views": {
+    "/backuppolicies": {
+      "menu": [
+        {
+          "label": "button.show.backups",
+          "link": "/ui/resource/list/backuppolicies/{organization}/{name}/backups"
+        }
+      ]
+    }
+  }
+}
+```
+
+Example using `dialog`:
+
+```json
+{
+  "views": {
+    "/databases": {
+      "menu-append": [
+        {
+          "label": "button.db.connection.info",
+          "icon": "Info",
+          "dialog": "DbConnectionInfo"
+        }
+      ]
+    }
+  }
+}
+```
+
+Currently Supported built-in dialogs:
+
+- `DbConnectionInfo`
+- `ChangeDbaPassword`
+
+Unknown dialog names fall back to a generic dialog showing an error and the row data.
+
+#### `menu-append`
+
+Appends menu entries to inherited ones.
+
+Example:
+
+```json
+{
+  "views": {
+    "/databases": {
+      "menu-append": [
+        {
+          "label": "button.sql.editor",
+          "icon": "Storage",
+          "visible": "hasSqlEditorService()",
+          "link": "/ui/page/sql/{organization}/{project}/{name}"
+        }
+      ]
+    }
+  }
+}
+```
+
+#### `links`
+
+The customization type defines `views.<path>.links.<field>`, where each entry supports:
+
+- `link`
+- `linkTarget` (optional)
+
+Example:
+
+```json
+{
+  "views": {
+    "/databases": {
+      "links": {
+        "name": {
+          "link": "https://example.com/{organization}/{project}/{name}",
+          "linkTarget": "_blank"
+        }
+      }
+    }
+  }
+}
+```
+
+## Form customizations
+
+The `forms` object customizes create, edit, and view layouts.
+
+Form definitions are matched by path using `matchesPath()`. Existing defaults in `base.json` use patterns such as:
+
+- `/users?/{organization}?/{name}`
+- `/projects?/{organization}?/{name}`
+- `/databases?/{organization}?/{project}?/{database}`
+- `/databases/{organization}/{project}/{name}`
+- `/backups?/{organization}?/{project}?/{database}?/{name}`
+- `/backuppolicies?/{organization}?/{name}`
+
+This allows one definition to match create, edit, and view style paths.
+
+### `sections`
+
+A form is divided into tab sections. Each section supports:
+
+- `title` (optional): tab title; if omitted, the section is treated as the general section
+- `fields`: field configuration map
+
+### `fields`
+
+Each field entry key is either:
+
+- a direct field name such as `name`
+- a nested field path such as `roles.admin` or `selector.matchLabels`
+- `*` to include all remaining fields not explicitly assigned earlier
+
+Supported field properties:
+
+- `required`: marks the field required
+- `expand`: controls expansion for object fields
+- `hidden`: hides the field
+
+Example form layout:
+
+```json
+{
+  "forms": {
+    "/backuppolicies?/{organization}?/{name}": {
+      "sections": [
+        {
+          "fields": {
+            "organization": {},
+            "name": {},
+            "frequency": {},
+            "suspended": {}
+          }
+        },
+        {
+          "title": "section.title.database.selection",
+          "fields": {
+            "selector": {
+              "expand": false
+            }
+          }
+        },
+        {
+          "title": "section.title.database.retention",
+          "fields": {
+            "retention": {}
+          }
+        },
+        {
+          "title": "section.title.advanced",
+          "fields": {
+            "*": {}
+          }
+        }
+      ]
+    }
+  }
+}
+```
+
+Example hiding a nested field:
+
+```json
+{
+  "forms": {
+    "/users?/{organization}?/{name}": {
+      "sections": [
+        {
+          "fields": {
+            "organization": {},
+            "name": {},
+            "password": {},
+            "roles.admin": {
+              "hidden": true
+            }
+          }
+        },
+        {
+          "title": "section.title.advanced",
+          "fields": {
+            "*": {}
+          }
+        }
+      ]
+    }
+  }
+}
+```
+
+Example forcing an object field collapsed:
+
+```json
+{
+  "forms": {
+    "/users?/{organization}?/{name}": {
+      "sections": [
+        {
+          "title": "section.title.access.deny.rules",
+          "fields": {
+            "accessRule": {
+              "expand": false
+            }
+          }
+        }
+      ]
+    }
+  }
+}
+```
+
+## Formula syntax
+
+Formulas are used by `views.<path>.fields.<field>.value` and `views.<path>.menu[].visible`.
+
+They are evaluated against the current row object. Supported syntax:
+
+- field lookup: `status.state`
+- logical NOT: `!maintenance`
+- boolean cast: `!!field`
+- equality: `maintenance.isDisabled=false`
+- inequality: `field!=otherField`
+- logical AND: `fieldA&fieldB`
+- logical OR: `fieldA|fieldB`
+- string constants in double quotes: `field=="value"`
+- boolean constants: `true`, `false`
+- special function: `hasSqlEditorService()`
+
+Notes:
+
+- for security reasons, formulas are intentionally simple and are not JavaScript expressions
+- spaces are tolerated in formulas
+- values are resolved from the current row object
+- invalid formulas evaluate to an empty string
+
+Examples:
+
+```json
+{
+  "views": {
+    "/databases": {
+      "fields": {
+        "status": {
+          "value": "status.state"
+        }
+      },
+      "menu-append": [
+        {
+          "label": "button.sql.editor",
+          "visible": "hasSqlEditorService()",
+          "link": "/ui/page/sql/{organization}/{project}/{name}"
+        },
+        {
+          "label": "confirm.stop.database.title",
+          "visible": "!maintenance",
+          "patch": [
+            {
+              "op": "add",
+              "path": "/maintenance",
+              "value": {
+                "isDisabled": true
+              }
+            }
+          ]
+        }
+      ]
+    }
+  }
+}
+```
+
+## Path placeholders and substitutions
+
+Several customization values support row-based placeholder substitution such as:
+
+- `{organization}`
+- `{project}`
+- `{name}`
+
+This is used for links and translated labels/confirmations that receive the row object as interpolation data.
+
+Example:
+
+```json
+{
+  "views": {
+    "/projects": {
+      "menu": [
+        {
+          "label": "button.show.databases",
+          "link": "/ui/resource/list/databases/{organization}/{name}"
+        }
+      ]
+    }
+  }
+}
+```
+
+## User settings and saved column layouts
+
+The Settings page allows a user to edit raw customization JSON and save it into local storage. Table column selection changes made in the UI are also written back into local storage under the matching `views.<path>.columns` setting.
+
+This means administrators can provide defaults in `base.json` / `custom.json`, while users can still override them locally.
+
+## Practical examples
+
+### Example: customer-specific overrides in `custom.json`
+
+```json
+{
+  "theme": {
+    "css": "/ui/theme/customer.css"
+  },
+  "views": {
+    "/databases": {
+      "fields": {
+        "status": {
+          "label": "Database status",
+          "value": "status.state"
+        }
+      },
+      "menu-append": [
+        {
+          "label": "button.sql.editor",
+          "icon": "Storage",
+          "visible": "hasSqlEditorService()",
+          "link": "/ui/page/sql/{organization}/{project}/{name}"
+        }
+      ]
+    }
+  }
+}
+```
+
+### Example: replace all backup policy actions
+
+```json
+{
+  "views": {
+    "/backuppolicies": {
+      "menu": [
+        {
+          "label": "button.show.backups",
+          "icon": "Info",
+          "link": "/ui/resource/list/backuppolicies/{organization}/{name}/backups"
+        }
+      ]
+    }
+  }
+}
+```
+
+### Example: append one extra backup policy action without losing defaults
+
+```json
+{
+  "views": {
+    "/backuppolicies": {
+      "menu-append": [
+        {
+          "label": "button.show.databases",
+          "icon": "Info",
+          "link": "/ui/resource/list/backuppolicies/{organization}/{name}/databases"
+        }
+      ]
+    }
+  }
+}
+```
+
+### Example: reorganize database form tabs
+
+```json
+{
+  "forms": {
+    "/databases?/{organization}?/{project}?/{database}": {
+      "sections": [
+        {
+          "fields": {
+            "organization": {},
+            "project": {},
+            "name": {},
+            "dbaPassword": {}
+          }
+        },
+        {
+          "title": "section.title.labels",
+          "fields": {
+            "labels": {},
+            "properties": {}
+          }
+        },
+        {
+          "title": "section.title.advanced",
+          "fields": {
+            "*": {}
+          }
+        }
+      ]
+    }
+  }
+}
+```
+
+### Example: site default plus user-local append
+
+Server-side `custom.json`:
+
+```json
+{
+  "views": {
+    "/projects": {
+      "columns": ["name", "organization", "sla", "tier"]
+    }
+  }
+}
+```
+
+User-local settings:
+
+```json
+{
+  "views": {
+    "/projects": {
+      "columns-append": ["labels"]
+    }
+  }
+}
+```
+
+After merging, the effective columns become:
+
+```json
+["name", "organization", "sla", "tier", "labels"]
+```

--- a/ui/customizations.md
+++ b/ui/customizations.md
@@ -172,7 +172,8 @@ Server-provided customization files are read from:
 
 User-specific customizations are edited in the UI settings page and stored in browser local storage under `nuodbaas_webui_userSettings`.
 
-The `custom.json` file is intended to override or extend the defaults from `base.json`. This file can be replaced by volume-mounting the docker container at `/usr/share/nginx/html/theme/custom.json` or by setting the helm value `nuodbaasWebui.customJson` with the content of the file (i.e. by using the `--set-file` option.
+The `custom.json` file is intended to override or extend the defaults from `base.json`. This file can be replaced by volume-mounting the docker container at `/usr/share/nginx/html/theme/custom.json` or by setting the helm value `nuodbaasWebui.cu
+stomConfig` with the content of the file (i.e. by using the `--set-file` option.
 
 ## `views` customizations
 

--- a/ui/customizations.md
+++ b/ui/customizations.md
@@ -192,13 +192,7 @@ Example:
 {
   "views": {
     "/backuppolicies": {
-      "columns": [
-        "name",
-        "organization",
-        "frequency",
-        "selector",
-        "retention"
-      ]
+      "columns": ["name", "organization", "frequency", "selector", "retention"]
     }
   }
 }

--- a/ui/index.html
+++ b/ui/index.html
@@ -5,8 +5,6 @@
     <meta charset="utf-8" />
     <link rel="icon" href="favicon.ico" />
     <link rel="stylesheet" href="/theme/base.css" />
-    <link id="theme_stylesheet" rel=" stylesheet" href="/theme/material.css" />
-    <link id="user_stylesheet" rel="stylesheet" href="" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
     <meta name="description" content="NuoDBaaS WebUI" />

--- a/ui/public/theme/base.css
+++ b/ui/public/theme/base.css
@@ -1223,3 +1223,11 @@ label.NuoUpload:hover {
   border: 1px solid lightgray;
   border-collapse: collapse;
 }
+
+.BannerItem {
+  color: white !important;
+}
+
+.NuoBannerMenu>button {
+  color: white !important;
+}

--- a/ui/public/theme/base.css
+++ b/ui/public/theme/base.css
@@ -1228,6 +1228,6 @@ label.NuoUpload:hover {
   color: white !important;
 }
 
-.NuoBannerMenu>button {
+.NuoBannerMenu > button {
   color: white !important;
 }

--- a/ui/public/theme/custom.json
+++ b/ui/public/theme/custom.json
@@ -1,0 +1,3 @@
+{
+  "copyright": "(C) Copyright 2026 Dassault Systemes SE.  All Rights Reserved.",
+}

--- a/ui/public/theme/custom.json
+++ b/ui/public/theme/custom.json
@@ -1,3 +1,3 @@
 {
-  "copyright": "(C) Copyright 2026 Dassault Systemes SE.  All Rights Reserved.",
+  "copyright": "(C) Copyright 2026 Dassault Systemes SE.  All Rights Reserved."
 }

--- a/ui/public/theme/material.css
+++ b/ui/public/theme/material.css
@@ -1,7 +1,0 @@
-/* (C) Copyright 2024-2026 Dassault Systemes SE.  All Rights Reserved. */
-.BannerItem {
-  color: white !important;
-}
-.NuoBannerMenu > button {
-  color: white !important;
-}

--- a/ui/public/theme/material.json
+++ b/ui/public/theme/material.json
@@ -1,3 +1,0 @@
-{
-  "copyright": "(C) Copyright 2024-2026 Dassault Systemes SE.  All Rights Reserved."
-}

--- a/ui/src/components/pages/parts/ResourcePopupMenu.tsx
+++ b/ui/src/components/pages/parts/ResourcePopupMenu.tsx
@@ -201,7 +201,7 @@ export default function ResourcePopupMenu({
                     );
                   });
                 } else if (menu.link) {
-                  const link = replaceVariables(menu.link, row);
+                  const link = replaceVariables(menu.link, row, true);
                   if (
                     !menu.linkTarget &&
                     !link.startsWith("//") &&

--- a/ui/src/components/pages/parts/ResourcePopupMenu.tsx
+++ b/ui/src/components/pages/parts/ResourcePopupMenu.tsx
@@ -202,10 +202,13 @@ export default function ResourcePopupMenu({
                   });
                 } else if (menu.link) {
                   const link = replaceVariables(menu.link, row);
-                  if (!menu.linkTarget && !link.startsWith("//") && link.indexOf("://") === -1) {
+                  if (
+                    !menu.linkTarget &&
+                    !link.startsWith("//") &&
+                    link.indexOf("://") === -1
+                  ) {
                     navigate(link);
-                  }
-                  else {
+                  } else {
                     window.open(link, menu.linkTarget);
                   }
                 } else if (menu.dialog) {

--- a/ui/src/components/pages/parts/ResourcePopupMenu.tsx
+++ b/ui/src/components/pages/parts/ResourcePopupMenu.tsx
@@ -202,8 +202,11 @@ export default function ResourcePopupMenu({
                   });
                 } else if (menu.link) {
                   const link = replaceVariables(menu.link, row);
-                  if (!link.startsWith("//") && link.indexOf("://") === -1) {
+                  if (!menu.linkTarget && !link.startsWith("//") && link.indexOf("://") === -1) {
                     navigate(link);
+                  }
+                  else {
+                    window.open(link, menu.linkTarget);
                   }
                 } else if (menu.dialog) {
                   CustomDialog({ dialog: menu.dialog, path, data: row, t });

--- a/ui/src/components/pages/parts/Table.tsx
+++ b/ui/src/components/pages/parts/Table.tsx
@@ -328,7 +328,7 @@ function Table(props: TableProps) {
 
     // provide custom link
     if (cv?.links?.[fieldName]?.link) {
-      const link = replaceVariables(cv.links[fieldName].link, row);
+      const link = replaceVariables(cv.links[fieldName].link, row, true);
       const linkTarget = cv.links[fieldName].linkTarget;
       return (
         <button

--- a/ui/src/components/pages/parts/Table.tsx
+++ b/ui/src/components/pages/parts/Table.tsx
@@ -16,6 +16,7 @@ import {
   getSchemaPath,
   hasActiveStream,
   getEntryPath,
+  replaceVariables,
 } from "../../../utils/schema";
 import { Rest } from "./Rest";
 import Dialog from "./Dialog";
@@ -310,19 +311,49 @@ function Table(props: TableProps) {
       });
     }
 
-    return fieldName === "name" ? (
-      <button
-        key={row["$ref"]}
-        onClick={(event) => {
-          event.preventDefault();
-          navigate("/ui/resource/view" + path + "/" + row["$ref"]);
-        }}
-      >
-        {value}
-      </button>
-    ) : (
-      value
-    );
+    // provide link to view entry
+    if (fieldName === "name") {
+      return (
+        <button
+          key={row["$ref"]}
+          onClick={(event) => {
+            event.preventDefault();
+            navigate("/ui/resource/view" + path + "/" + row["$ref"]);
+          }}
+        >
+          {value}
+        </button>
+      );
+    }
+
+    // provide custom link
+    if (cv?.links?.[fieldName]?.link) {
+      const link = replaceVariables(cv.links[fieldName].link, row);
+      const linkTarget = cv.links[fieldName].linkTarget;
+      return (
+        <button
+          className="NuoLinkButton"
+          key={row["$ref"]}
+          onClick={(event) => {
+            event.preventDefault();
+            if (
+              !linkTarget &&
+              !link.startsWith("//") &&
+              link.indexOf("://") === -1
+            ) {
+              navigate(link);
+            } else {
+              window.open(link, linkTarget);
+            }
+          }}
+        >
+          {value}
+        </button>
+      );
+    }
+
+    // show value
+    return value;
   }
 
   function moveNameColumnToFront(columns: MenuItemProps[]) {

--- a/ui/src/utils/Customizations.tsx
+++ b/ui/src/utils/Customizations.tsx
@@ -323,7 +323,7 @@ export default function Customizations(
   async function initCustomizations() {
     // retrieve all configuration files
     const baseJson = (await axios.get("/ui/theme/base.json")).data || {};
-    const customJson = (await axios.get("/ui/theme/custom.json")).data || {};
+    const customConfig = (await axios.get("/ui/theme/custom.json")).data || {};
     const userJson = JSON.parse(
       localStorage.getItem(LOCAL_USER_SETTINGS) || "{}",
     );
@@ -338,7 +338,7 @@ export default function Customizations(
 
     // merge configuration files together
     let merged = baseJson;
-    mergeRecursive(merged, customJson);
+    mergeRecursive(merged, customConfig);
     mergeRecursive(merged, userJson);
     mergedJson = merged;
 

--- a/ui/src/utils/Customizations.tsx
+++ b/ui/src/utils/Customizations.tsx
@@ -42,6 +42,7 @@ export type CustomViewMenu = {
   confirm: string;
   dialog?: string;
   link?: string;
+  linkTarget?: string;
 };
 
 export type CustomViewFields = { [key: string]: CustomViewField };
@@ -258,6 +259,15 @@ function isObject(item: any): boolean {
 }
 
 /**
+ * Simple array check.
+ * @param item
+ * @returns {boolean}
+ */
+function isArray(item: any): boolean {
+  return item && typeof item === "object" && Array.isArray(item);
+}
+
+/**
  * Deep merge two objects.
  * @param merged object where data is merged into
  * @param data object to apply to the merged object
@@ -270,7 +280,15 @@ export function mergeRecursive(merged: any, data: any): void {
       }
       mergeRecursive(merged[key], data[key]);
     } else {
-      merged[key] = data[key];
+      const keyWithoutAppend = key.endsWith("-append") ? key.substring(0, key.length - "-append".length) : key;
+      if (isArray(data[key]) && key.endsWith("-append") && isArray(merged[keyWithoutAppend])) {
+        data[key].forEach((value: any) => {
+          merged[keyWithoutAppend].push(value);
+        })
+      }
+      else {
+        merged[key] = data[key];
+      }
     }
   }
 }
@@ -294,13 +312,10 @@ export default function Customizations(
   async function initCustomizations() {
     // retrieve all configuration files
     const baseJson = (await axios.get("/ui/theme/base.json")).data || {};
+    const customJson = (await axios.get("/ui/theme/custom.json")).data || {};
     const userJson = JSON.parse(
       localStorage.getItem(LOCAL_USER_SETTINGS) || "{}",
     );
-    const themeType =
-      userJson?.theme?.type || baseJson?.theme?.type || "material";
-    const themeJson =
-      (await axios.get("/ui/theme/" + themeType + ".json")).data || {};
 
     try {
       hasSqlEditorService = (
@@ -312,30 +327,10 @@ export default function Customizations(
 
     // merge configuration files together
     let merged = baseJson;
-    mergeRecursive(merged, themeJson || {});
+    mergeRecursive(merged, customJson);
     mergeRecursive(merged, userJson);
     mergedJson = merged;
 
-    // loading theme + user CSS files
-    const themeCss = document.getElementById("theme_stylesheet");
-    themeCss?.setAttribute("href", "/ui/theme/material.css");
-
-    const userCss = document.getElementById("user_stylesheet");
-    if (userCss && mergedJson?.theme?.css) {
-      const css = mergedJson.theme.css;
-      if (
-        css.startsWith("http://") ||
-        css.startsWith("https://") ||
-        css.startsWith("/")
-      ) {
-        userCss.setAttribute("href", css);
-      } else {
-        const urlCSS = URL.createObjectURL(
-          new Blob([css], { type: "text/css" }),
-        );
-        userCss.setAttribute("href", urlCSS);
-      }
-    }
     setDone(true);
   }
 

--- a/ui/src/utils/Customizations.tsx
+++ b/ui/src/utils/Customizations.tsx
@@ -51,6 +51,12 @@ export type CustomView = {
   columns?: string[];
   fields?: CustomViewFields;
   menu?: CustomViewMenu[];
+  links?: {
+    [key: string]: {
+      link: string;
+      linkTarget?: string;
+    };
+  };
 };
 
 export type CustomViews = { [key: string]: CustomView };
@@ -280,13 +286,18 @@ export function mergeRecursive(merged: any, data: any): void {
       }
       mergeRecursive(merged[key], data[key]);
     } else {
-      const keyWithoutAppend = key.endsWith("-append") ? key.substring(0, key.length - "-append".length) : key;
-      if (isArray(data[key]) && key.endsWith("-append") && isArray(merged[keyWithoutAppend])) {
+      const keyWithoutAppend = key.endsWith("-append")
+        ? key.substring(0, key.length - "-append".length)
+        : key;
+      if (
+        isArray(data[key]) &&
+        key.endsWith("-append") &&
+        isArray(merged[keyWithoutAppend])
+      ) {
         data[key].forEach((value: any) => {
           merged[keyWithoutAppend].push(value);
-        })
-      }
-      else {
+        });
+      } else {
         merged[key] = data[key];
       }
     }

--- a/ui/src/utils/schema.ts
+++ b/ui/src/utils/schema.ts
@@ -264,10 +264,11 @@ export function replaceVariables(
         search.substring(0, posOpenBracket) +
         search.substring(posOpenBracket + 1);
     } else {
-      let value = getValue(
-        variables,
-        search.substring(posOpenBracket + 1, posCloseBracket),
-      );
+      let value =
+        getValue(
+          variables,
+          search.substring(posOpenBracket + 1, posCloseBracket),
+        ) || "";
       if (urlEncode) {
         value = encodeURIComponent(value);
       }

--- a/ui/src/utils/schema.ts
+++ b/ui/src/utils/schema.ts
@@ -250,7 +250,11 @@ export function getOrgFromPath(schema: SchemaType, path: string) {
  * @param {*} variables
  * @returns string with the placeholders replaced.
  */
-export function replaceVariables(search: string, variables: TempAny, urlEncode: boolean): string {
+export function replaceVariables(
+  search: string,
+  variables: TempAny,
+  urlEncode: boolean,
+): string {
   let posOpenBracket;
   while ((posOpenBracket = search.indexOf("{")) !== -1) {
     const posCloseBracket = search.indexOf("}", posOpenBracket + 1);
@@ -261,12 +265,12 @@ export function replaceVariables(search: string, variables: TempAny, urlEncode: 
         search.substring(posOpenBracket + 1);
     } else {
       let value = getValue(
-          variables,
-          search.substring(posOpenBracket + 1, posCloseBracket),
-        );
-        if (urlEncode) {
-          value = encodeURIComponent(value);
-        }
+        variables,
+        search.substring(posOpenBracket + 1, posCloseBracket),
+      );
+      if (urlEncode) {
+        value = encodeURIComponent(value);
+      }
       search =
         search.substring(0, posOpenBracket) +
         value +

--- a/ui/src/utils/schema.ts
+++ b/ui/src/utils/schema.ts
@@ -10,6 +10,7 @@ import {
   SchemaType,
   FieldParametersType,
 } from "./types";
+import { getValue } from "../components/fields/utils";
 let schema: TempAny = null;
 
 export const Feature: { FILTER_ON_SERVER: boolean | undefined } = {
@@ -250,9 +251,24 @@ export function getOrgFromPath(schema: SchemaType, path: string) {
  * @returns string with the placeholders replaced.
  */
 export function replaceVariables(search: string, variables: TempAny): string {
-  Object.keys(variables).forEach((key) => {
-    search = search.replaceAll("{" + key + "}", variables[key]);
-  });
+  let posOpenBracket;
+  while ((posOpenBracket = search.indexOf("{")) !== -1) {
+    const posCloseBracket = search.indexOf("}", posOpenBracket + 1);
+    if (posCloseBracket === -1) {
+      //missing close bracket - this shouldn't occur - just get rid of the open bracket
+      search =
+        search.substring(0, posOpenBracket) +
+        search.substring(posOpenBracket + 1);
+    } else {
+      search =
+        search.substring(0, posOpenBracket) +
+        getValue(
+          variables,
+          search.substring(posOpenBracket + 1, posCloseBracket),
+        ) +
+        search.substring(posCloseBracket + 1);
+    }
+  }
   return search;
 }
 

--- a/ui/src/utils/schema.ts
+++ b/ui/src/utils/schema.ts
@@ -250,7 +250,7 @@ export function getOrgFromPath(schema: SchemaType, path: string) {
  * @param {*} variables
  * @returns string with the placeholders replaced.
  */
-export function replaceVariables(search: string, variables: TempAny): string {
+export function replaceVariables(search: string, variables: TempAny, urlEncode: boolean): string {
   let posOpenBracket;
   while ((posOpenBracket = search.indexOf("{")) !== -1) {
     const posCloseBracket = search.indexOf("}", posOpenBracket + 1);
@@ -260,12 +260,16 @@ export function replaceVariables(search: string, variables: TempAny): string {
         search.substring(0, posOpenBracket) +
         search.substring(posOpenBracket + 1);
     } else {
-      search =
-        search.substring(0, posOpenBracket) +
-        getValue(
+      let value = getValue(
           variables,
           search.substring(posOpenBracket + 1, posCloseBracket),
-        ) +
+        );
+        if (urlEncode) {
+          value = encodeURIComponent(value);
+        }
+      search =
+        search.substring(0, posOpenBracket) +
+        value +
         search.substring(posCloseBracket + 1);
     }
   }


### PR DESCRIPTION
Before, only users could customize the views / forms for their browser session. With this PR an additional `custom.json` file is included in the WebUI which can be overwritten by the `nuodbaasWebui.customJson` value containing the content of a JSON file.

Changes performed:
- added `nuodbaasWebui.customJson` helm value to use a UI customizations per environment
- added `ds.com/abc=abc` label when deploying a test database in dev + test environment
- added e2e testing for customized `custom.json` file
- removed obsolete Material UI customization files
- added feature to redirect a popup menu item to an internal or external link
- added feature to customize list entries by replacing a static value with a link which can point to external sites. The link can contain variable placeholders from the actual document
- removed obsolete CSS style theming (is also an XSS risk)