### PR TITLE
fix copy on Windows (had missing newlines)

### DIFF
--- a/ui/src/components/pages/Automation.tsx
+++ b/ui/src/components/pages/Automation.tsx
@@ -199,7 +199,7 @@ function Automation(props: PageProps) {
           <ContentCopyOutlinedIcon
             className="NuoCopyButton"
             onClick={() => {
-              navigator.clipboard.writeText(lines.join("\n")).then(() => {
+              navigator.clipboard.writeText(lines.join("\r\n")).then(() => {
                 setCopiedField(summary);
                 if (copiedTimeout) {
                   clearTimeout(copiedTimeout);

--- a/ui/src/components/pages/custom/DbConnectionInfo.tsx
+++ b/ui/src/components/pages/custom/DbConnectionInfo.tsx
@@ -170,7 +170,7 @@ export default function DbConnectionInfo({ data, t }: DbConnectionInfoProps) {
             data-testid={"copy-" + fieldname}
             className="NuoCopyButton"
             onClick={() => {
-              navigator.clipboard.writeText(value).then(() => {
+              navigator.clipboard.writeText(value.replace(/\n/g, "\r\n")).then(() => {
                 setCopiedField(fieldname);
                 if (copiedTimeout) {
                   clearTimeout(copiedTimeout);
@@ -187,7 +187,7 @@ export default function DbConnectionInfo({ data, t }: DbConnectionInfoProps) {
             name={fieldname}
             data-testid={"value-" + fieldname}
             disabled={true}
-            value={value}
+            value={value.replace(/\n/g, "\r\n")}
           ></Textarea>
         ) : (
           <input
@@ -217,7 +217,7 @@ export default function DbConnectionInfo({ data, t }: DbConnectionInfoProps) {
             data-testid={"copy-" + dataTestid}
             className="NuoCopyButton"
             onClick={() => {
-              navigator.clipboard.writeText(lines.join("\n")).then(() => {
+              navigator.clipboard.writeText(lines.join("\r\n")).then(() => {
                 setCopiedField(summary);
                 if (copiedTimeout) {
                   clearTimeout(copiedTimeout);

--- a/ui/src/components/pages/custom/DbConnectionInfo.tsx
+++ b/ui/src/components/pages/custom/DbConnectionInfo.tsx
@@ -170,15 +170,17 @@ export default function DbConnectionInfo({ data, t }: DbConnectionInfoProps) {
             data-testid={"copy-" + fieldname}
             className="NuoCopyButton"
             onClick={() => {
-              navigator.clipboard.writeText(value.replace(/\n/g, "\r\n")).then(() => {
-                setCopiedField(fieldname);
-                if (copiedTimeout) {
-                  clearTimeout(copiedTimeout);
-                }
-                copiedTimeout = setTimeout(() => {
-                  setCopiedField("");
-                }, 2000);
-              });
+              navigator.clipboard
+                .writeText(value.replace(/\n/g, "\r\n"))
+                .then(() => {
+                  setCopiedField(fieldname);
+                  if (copiedTimeout) {
+                    clearTimeout(copiedTimeout);
+                  }
+                  copiedTimeout = setTimeout(() => {
+                    setCopiedField("");
+                  }, 2000);
+                });
             }}
           />
         </Tooltip>

--- a/ui/src/components/pages/parts/MoreInline.tsx
+++ b/ui/src/components/pages/parts/MoreInline.tsx
@@ -10,6 +10,10 @@ type MoreInlineProps = {
 export default function MoreInline({ value, t }: MoreInlineProps) {
   const [expanded, setExpanded] = useState<boolean>(false);
 
+  if (!value) {
+    return value;
+  }
+
   let strValue = String(value);
   let moreValue = "";
   if (strValue.indexOf("\n") !== -1) {
@@ -20,16 +24,19 @@ export default function MoreInline({ value, t }: MoreInlineProps) {
     moreValue = strValue.substring(80) + moreValue;
     strValue = strValue.substring(0, 80);
   }
+  if (expanded) {
+    return <span style={{ whiteSpace: "pre-wrap" }}>{value.replace(/\n/g, "\r\n")}</span>
+  }
   return (
     <>
-      {strValue}
+      {!expanded && strValue}
       <div
         className="NuoMoreValue"
         onClick={(element: React.MouseEvent<HTMLDivElement>) => {
           setExpanded(true);
         }}
       >
-        {expanded ? value : <> {t("text.more")}</>}
+        {t("text.more")}
       </div>
     </>
   );

--- a/ui/src/components/pages/parts/MoreInline.tsx
+++ b/ui/src/components/pages/parts/MoreInline.tsx
@@ -25,7 +25,11 @@ export default function MoreInline({ value, t }: MoreInlineProps) {
     strValue = strValue.substring(0, 80);
   }
   if (expanded) {
-    return <span style={{ whiteSpace: "pre-wrap" }}>{value.replace(/\n/g, "\r\n")}</span>
+    return (
+      <span style={{ whiteSpace: "pre-wrap" }}>
+        {value.replace(/\n/g, "\r\n")}
+      </span>
+    );
   }
   return (
     <>


### PR DESCRIPTION
copying certificates resulted in lost newlines on Windows
- copy certificate from database view
- copy from "copy" icon on "Database Connection Info"'s certificate field
- copy from certificate field directly in "Database Connection Info"

Verified fix with a Windows laptop. Also verified on macOS that there are no empty lines.