### PR TITLE
support absolute URL's in login redirects

### DIFF
--- a/ui/src/components/pages/LoginForm.tsx
+++ b/ui/src/components/pages/LoginForm.tsx
@@ -45,18 +45,8 @@ function LoginForm({ setIsLoggedIn, t }: Props) {
   const [authHeader, setAuthHeader] = useState("");
   const [showLoginForm, setShowLoginForm] = useState(false);
   // Specify redirect URL so that provider name is supplied as query parameter
-  const queryRedirect =
-    queryParams.get("redirect") || queryParams.get("redirectUrl") || "";
-  const redirectUrl = encodeURIComponent(
-    window.location.protocol +
-      "//" +
-      window.location.host +
-      "/ui/login?provider={name}&redirectUrl=" +
-      window.location.protocol +
-      "//" +
-      window.location.host +
-      queryRedirect,
-  );
+  const redirectUrl = window.location.origin + "/ui/login?provider={name}&redirectUrl=" +
+      (new URL(queryParams.get("redirect") || queryParams.get("redirectUrl") || "", window.location.origin)).href;
 
   useEffect(() => {
     handleInitialLoad();
@@ -87,7 +77,7 @@ function LoginForm({ setIsLoggedIn, t }: Props) {
   async function fetchProviders() {
     try {
       const data = (await Rest.get(
-        `/login/providers?redirectUrl=${redirectUrl}`,
+        `/login/providers?redirectUrl=${encodeURIComponent(redirectUrl)}`,
       )) as ProvidersResponse | undefined;
       if (data?.items) {
         setProviders(data.items);
@@ -295,7 +285,7 @@ function LoginForm({ setIsLoggedIn, t }: Props) {
                 data-testid={`login_${provider.name}`}
                 variant="contained"
                 onClick={() =>
-                  (window.location.href = `${provider.url}&redirectUrl=${redirectUrl}`)
+                  (window.location.href = `${provider.url}&redirectUrl=${encodeURIComponent(redirectUrl)}`)
                 }
               >
                 {t("form.login.label.loginWith", {

--- a/ui/src/components/pages/LoginForm.tsx
+++ b/ui/src/components/pages/LoginForm.tsx
@@ -45,8 +45,13 @@ function LoginForm({ setIsLoggedIn, t }: Props) {
   const [authHeader, setAuthHeader] = useState("");
   const [showLoginForm, setShowLoginForm] = useState(false);
   // Specify redirect URL so that provider name is supplied as query parameter
-  const redirectUrl = window.location.origin + "/ui/login?provider={name}&redirectUrl=" +
-      (new URL(queryParams.get("redirect") || queryParams.get("redirectUrl") || "", window.location.origin)).href;
+  const redirectUrl =
+    window.location.origin +
+    "/ui/login?provider={name}&redirectUrl=" +
+    new URL(
+      queryParams.get("redirect") || queryParams.get("redirectUrl") || "",
+      window.location.origin,
+    ).href;
 
   useEffect(() => {
     handleInitialLoad();

--- a/ui/src/utils/BackgroundTasks.tsx
+++ b/ui/src/utils/BackgroundTasks.tsx
@@ -5,11 +5,7 @@ import { withTranslation } from "react-i18next";
 import { TFunction } from "i18next";
 
 export type StatusType =
-  | "not_started"
-  | "in_progress"
-  | "complete"
-  | "canceled"
-  | "error";
+  "not_started" | "in_progress" | "complete" | "canceled" | "error";
 export type BackgroundTaskType = {
   id: string;
   label: string;

--- a/ui/src/utils/schema.ts
+++ b/ui/src/utils/schema.ts
@@ -457,8 +457,7 @@ export function concatChunks(
 let eventTransaction = 0;
 
 let monitored:
-  | undefined
-  | { abort: AbortController; transactionNumber: number } = undefined;
+  undefined | { abort: AbortController; transactionNumber: number } = undefined;
 export function hasActiveStream(): boolean {
   return !!monitored;
 }


### PR DESCRIPTION
fixes issue where an absolute URL path in `?redirect=` or `?redirectUrl=` resulted in the origin being included twice in the URL.