### PR TITLE
do project SLA lookup only if needed

### DIFF
--- a/ui/src/components/pages/parts/Table.tsx
+++ b/ui/src/components/pages/parts/Table.tsx
@@ -140,6 +140,12 @@ function Table(props: TableProps) {
     });
 
     setColumns(cols);
+  }, [data, path, schema, t]);
+
+  useEffect(() => {
+    if (!Auth.hasSlaRules()) {
+      return;
+    }
 
     const pathParts = path.split("/");
     const organization = pathParts.length >= 3 ? pathParts[2] : undefined;
@@ -159,7 +165,7 @@ function Table(props: TableProps) {
       });
       setSlaByPath(newSlaByPath);
     });
-  }, [data, path, schema, t]);
+  }, [path]);
 
   useEffect(() => {
     setSelected(new Set<string>());

--- a/ui/src/utils/BackgroundTasks.tsx
+++ b/ui/src/utils/BackgroundTasks.tsx
@@ -5,11 +5,7 @@ import { withTranslation } from "react-i18next";
 import { TFunction } from "i18next";
 
 export type StatusType =
-  | "not_started"
-  | "in_progress"
-  | "complete"
-  | "canceled"
-  | "error";
+  "not_started" | "in_progress" | "complete" | "canceled" | "error";
 export type BackgroundTaskType = {
   id: string;
   label: string;

--- a/ui/src/utils/auth.ts
+++ b/ui/src/utils/auth.ts
@@ -242,6 +242,20 @@ export default class Auth {
     return false;
   }
 
+  static hasSlaRules(): boolean {
+    const accessRule = Auth.getAccessRule();
+    const allAccessRules = [
+      ...(accessRule.deny || []),
+      ...(accessRule.allow || []),
+    ];
+    for (let i = 0; i < allAccessRules.length; i++) {
+      if (allAccessRules[i].split(":").length >= 3) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   static logout() {
     this.setCredentials(null);
   }

--- a/ui/src/utils/schema.ts
+++ b/ui/src/utils/schema.ts
@@ -457,8 +457,7 @@ export function concatChunks(
 let eventTransaction = 0;
 
 let monitored:
-  | undefined
-  | { abort: AbortController; transactionNumber: number } = undefined;
+  undefined | { abort: AbortController; transactionNumber: number } = undefined;
 export function hasActiveStream(): boolean {
   return !!monitored;
 }


### PR DESCRIPTION
The project SLA lookup is needed to show "create", "edit" and "delete" buttons / checkboxes, so the user is only exposed to controls they have permissions to.

- do project SLA lookup only if authenticated user has SLA rules in their `accessRule` settings
- avoid multiple SLA lookups on a single resource view (it was triggered by `data`, `path`, `schema` and `t` changes - now it is only triggered by `path` changes) 