### PR TITLE
remove uneffective "more" link if the overflow is within margin

### DIFF
--- a/ui/public/theme/base.css
+++ b/ui/public/theme/base.css
@@ -707,6 +707,9 @@ code {
   height: 30px;
 }
 
+.NuoMap {
+  margin: 0;
+}
 .NuoLeftMenuCollapsed > .NuoComboBox,
 .NuoLeftMenuCollapsed * > .NuoComboBox {
   padding: 0 5px;

--- a/ui/src/components/fields/FieldBase.tsx
+++ b/ui/src/components/fields/FieldBase.tsx
@@ -146,7 +146,7 @@ export function getRecursiveValue(value: TempAny, t: TFunction) {
     } else {
       return (
         <MoreDiv maxHeight={150} t={t}>
-          <dl className="map">
+          <dl className="map NuoMap">
             {Object.keys(value).map((key) => {
               if (
                 typeof value[key] === "object" &&

--- a/ui/src/components/fields/FieldObject.tsx
+++ b/ui/src/components/fields/FieldObject.tsx
@@ -106,7 +106,7 @@ export default function FieldObject(props: FieldProps): ReactNode {
     }
     return (
       <MoreDiv maxHeight={150} t={props.t}>
-        <dl className="map">
+        <dl className="map NuoMap">
           {Object.keys(properties).map((key) => {
             const prefixKey = prefix ? prefix + "." + key : key;
             const fieldView = Field({

--- a/ui/src/components/fields/FieldUserRole.tsx
+++ b/ui/src/components/fields/FieldUserRole.tsx
@@ -188,7 +188,7 @@ export default function FieldUserRole(props: FieldProps): ReactNode {
       });
     }
     return (
-      <dl className="map">
+      <dl className="map NuoMap">
         {Object.keys(properties).map((key) => {
           const prefixKey = prefix ? prefix + "." + key : key;
           const fieldView = Field({


### PR DESCRIPTION
Bug: The `<dl>` tag has an upper/lower margin of `1em` or `14px`. the height of the content (including margin) is more than 150 pixels, but the content itself is less than 150 pixels, it will show a `More` link but when clicking it, it will show the remaining margin (with no additional text)

Fix: eliminate the `<dl>` margin. It is not needed since the parent container already has a margin (resulting in showing a double margin).

Note: The `map` class is composed by the MUI component aligning various `<dl>,<dt>,<dd>` tags