### PR TITLE
selected item in view which is deleted still shows as selected

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -415,7 +415,10 @@ start-dev-remote: setup-nginx-default-conf ## launch WebUI to remote Control Pla
 		; \
 	fi
 	(cd ui && npm install && npm start &)
-	docker run --rm -d --name nuodb-webui-dev -v `pwd`/docker/development/default.conf:/etc/nginx/conf.d/default.conf --network=host -it nginx:stable-alpine
+	docker run --rm -d --name nuodb-webui-dev \
+		-v `pwd`/docker/development/default.conf:/etc/nginx/conf.d/default.conf \
+		-v `pwd`/ui/public/theme/custom.json:/usr/share/nginx/html/theme/custom.json \
+		--network=host -it nginx:stable-alpine
 
 .PHONY: stop-dev-remote ## stop WebUI to remote Controll Plane
 stop-dev-remote:

--- a/charts/nuodbaas-webui/Chart.yaml
+++ b/charts/nuodbaas-webui/Chart.yaml
@@ -12,5 +12,5 @@ maintainers:
   email: support@nuodb.com
 icon: https://raw.githubusercontent.com/nuodb/nuodb-helm-charts/master/images/nuodb.svg
 type: application
-version: "1.4.0"
-appVersion: "1.4.0"
+version: "1.5.0"
+appVersion: "1.5.0"

--- a/ui/src/components/pages/ListResource.tsx
+++ b/ui/src/components/pages/ListResource.tsx
@@ -35,6 +35,7 @@ import Button from "../controls/Button";
 type ItemsAndPathProps = {
   items: DataType[] | null;
   path: string;
+  itemsTotal: number;
 };
 
 /**
@@ -49,6 +50,7 @@ function ListResource(props: PageProps) {
   const [itemsAndPath, setItemsAndPath] = useState<ItemsAndPathProps>({
     items: null,
     path,
+    itemsTotal: 0,
   });
   const [page, setPage] = useState(1);
   const [allItems, setAllItems] = useState([]);
@@ -125,16 +127,20 @@ function ListResource(props: PageProps) {
                   if (data.items.length > 0 && data.items[0]["$isNew"]) {
                     setShowReloadButton(true);
                   }
-                  setItemsAndPath({ items: data.items, path });
+                  setItemsAndPath({
+                    items: data.items,
+                    path,
+                    itemsTotal: data.total,
+                  });
                   setAllFieldNames(makeFieldnameList("", data.items));
                 } else {
-                  setItemsAndPath({ items: [], path });
+                  setItemsAndPath({ items: [], path, itemsTotal: 0 });
                 }
               },
               (error: TempAny) => {
                 Auth.handle401Error(error);
                 Toast.show("Error retrieving entry", error);
-                setItemsAndPath({ items: [], path });
+                setItemsAndPath({ items: [], path, itemsTotal: 0 });
               },
               () => {
                 setShowReloadButton(true);
@@ -247,7 +253,7 @@ function ListResource(props: PageProps) {
               sort={sort}
               setSort={setSort}
             />
-            {renderPaging(allItems.length)}
+            {renderPaging(itemsAndPath.itemsTotal)}
           </div>
         </div>
       </PageLayout>

--- a/ui/src/components/pages/parts/Table.tsx
+++ b/ui/src/components/pages/parts/Table.tsx
@@ -176,7 +176,7 @@ function Table(props: TableProps) {
 
   useEffect(() => {
     const dataRefs = new Set(data.map((d: { ["$ref"]: string }) => d["$ref"]));
-    setSelected(new Set([...selected].filter(s => dataRefs.has(s))));
+    setSelected(new Set([...selected].filter((s) => dataRefs.has(s))));
   }, [data]);
 
   type TableLabelsType = {

--- a/ui/src/components/pages/parts/Table.tsx
+++ b/ui/src/components/pages/parts/Table.tsx
@@ -174,6 +174,11 @@ function Table(props: TableProps) {
     setSelected(new Set<string>());
   }, [path, schema]);
 
+  useEffect(() => {
+    const dataRefs = new Set(data.map((d: { ["$ref"]: string }) => d["$ref"]));
+    setSelected(new Set([...selected].filter(s => dataRefs.has(s))));
+  }, [data]);
+
   type TableLabelsType = {
     [key: string]: string;
   };

--- a/ui/src/utils/schema.ts
+++ b/ui/src/utils/schema.ts
@@ -490,7 +490,7 @@ export function getResourceEvents(
       let event = null;
       let data = null;
       let id: string = "";
-      let mergedData: ResourcesType = { items: [] };
+      let mergedData: ResourcesType = { items: [], total: 0 };
       let buffer = Uint8Array.of();
       for await (const chunk of response) {
         buffer = concatChunks(buffer, chunk);

--- a/ui/src/utils/types.ts
+++ b/ui/src/utils/types.ts
@@ -112,4 +112,5 @@ export type DataType = {
 
 export type ResourcesType = {
   items: DataType[];
+  total: number;
 };


### PR DESCRIPTION
Bug: If a user selects a resource via checking a checkbox in a resource view, it shows the "Delete" button on the left side of the table header. If the user deletes the item via the popup menu on the RIGHT side, the resource disappears from the view but the "Delete" button on the left table header still remains.
Fixed by updating the selection list if the data rows change (remove all items not shown in the data rows).

Additional fixes:
- fix total pages if a search term is used
- fix missing config.json on `make start-dev-remote`