### PR TITLE
move db schema from login page to SQL query/Browse/import/export pages

### DIFF
--- a/ui-test/advanced/sql.spec.ts
+++ b/ui-test/advanced/sql.spec.ts
@@ -52,10 +52,29 @@ async function loginSqlEditor(page: Page): Promise<void> {
 
   await replaceInputOrTextareaByName(page, "dbUsername", DB_USERNAME);
   await replaceInputOrTextareaByName(page, "dbPassword", DB_PASSWORD);
-  await replaceInputOrTextareaByName(page, "dbSchema", DB_SCHEMA);
   await page.getByTestId("sql.login.button").click();
   await waitRestComplete(page);
 }
+
+export async function replaceSqlQuery(
+  page: Page,
+  value: string,
+): Promise<void> {
+  const editor = page.locator('.cm-content');
+
+  // Ensure the editor is fully visible and ready
+  await expect(editor).toBeVisible();
+
+  // 3. Clear existing text in CodeMirror
+  // CodeMirror doesn't always clear using standard .fill("") due to internal state tracking
+  await editor.focus();
+  await page.keyboard.press('Control+A'); // Use 'Meta+A' if testing purely on macOS
+  await page.keyboard.press('Backspace');
+
+  // 4. Type text dynamically into CodeMirror
+  await editor.fill(value);
+}
+
 
 /** Verifies the SQL user exists in the table, checks all role options, then deletes it. */
 async function verifyAndDeleteDbUser(page: Page, user: string): Promise<void> {
@@ -112,9 +131,8 @@ test.describe("SqlTests", () => {
 
     // Run DDL + DML + SELECT
     await page.getByTestId("query").click();
-    await replaceInputByName(
+    await replaceSqlQuery(
       page,
-      "sqlQuery",
       "create table table1 (name VARCHAR(80))",
     );
     await page.getByTestId("submitSql").click();
@@ -122,9 +140,8 @@ test.describe("SqlTests", () => {
 
     await page.getByTestId("query").click();
     await sleep(1000); // TODO(agr22)
-    await replaceInputByName(
+    await replaceSqlQuery(
       page,
-      "sqlQuery",
       "insert into table1 (name) values ('abc')",
     );
     await page.getByTestId("submitSql").click();
@@ -132,7 +149,7 @@ test.describe("SqlTests", () => {
 
     await sleep(1000); // TODO(agr22)
     await page.getByTestId("query").click();
-    await replaceInputByName(page, "sqlQuery", "select * from table1");
+    await replaceSqlQuery(page, "select * from table1");
     await page.getByTestId("submitSql").click();
     await waitRestComplete(page);
 

--- a/ui-test/advanced/sql.spec.ts
+++ b/ui-test/advanced/sql.spec.ts
@@ -60,7 +60,7 @@ export async function replaceSqlQuery(
   page: Page,
   value: string,
 ): Promise<void> {
-  const editor = page.locator('.cm-content');
+  const editor = page.locator(".cm-content");
 
   // Ensure the editor is fully visible and ready
   await expect(editor).toBeVisible();
@@ -68,13 +68,12 @@ export async function replaceSqlQuery(
   // 3. Clear existing text in CodeMirror
   // CodeMirror doesn't always clear using standard .fill("") due to internal state tracking
   await editor.focus();
-  await page.keyboard.press('Control+A'); // Use 'Meta+A' if testing purely on macOS
-  await page.keyboard.press('Backspace');
+  await page.keyboard.press("Control+A"); // Use 'Meta+A' if testing purely on macOS
+  await page.keyboard.press("Backspace");
 
   // 4. Type text dynamically into CodeMirror
   await editor.fill(value);
 }
-
 
 /** Verifies the SQL user exists in the table, checks all role options, then deletes it. */
 async function verifyAndDeleteDbUser(page: Page, user: string): Promise<void> {
@@ -131,19 +130,13 @@ test.describe("SqlTests", () => {
 
     // Run DDL + DML + SELECT
     await page.getByTestId("query").click();
-    await replaceSqlQuery(
-      page,
-      "create table table1 (name VARCHAR(80))",
-    );
+    await replaceSqlQuery(page, "create table table1 (name VARCHAR(80))");
     await page.getByTestId("submitSql").click();
     await waitRestComplete(page);
 
     await page.getByTestId("query").click();
     await sleep(1000); // TODO(agr22)
-    await replaceSqlQuery(
-      page,
-      "insert into table1 (name) values ('abc')",
-    );
+    await replaceSqlQuery(page, "insert into table1 (name) values ('abc')");
     await page.getByTestId("submitSql").click();
     await waitRestComplete(page);
 

--- a/ui/package.json
+++ b/ui/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "type": "module",
   "dependencies": {
+    "@codemirror/lang-sql": "^6.10.0",
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.0",
     "@fontsource/roboto": "^5.2.5",
@@ -12,6 +13,7 @@
     "@popperjs/core": "^2.11.8",
     "@types/react": "^19.1.3",
     "@types/react-dom": "^19.1.3",
+    "@uiw/react-codemirror": "^4.25.10",
     "axios": "^1.9.0",
     "i18next": "^26.0.3",
     "i18next-browser-languagedetector": "^8.2.1",

--- a/ui/src/components/pages/SqlPage.tsx
+++ b/ui/src/components/pages/SqlPage.tsx
@@ -96,14 +96,16 @@ function SqlTabs({ dbTable, sqlConnection, tasks, setTasks }: SqlTabsProps) {
   );
 }
 
+let schemasCache: string[] | undefined = undefined;
 let tablesCache: string[] | undefined = undefined;
 
 function SqlPage(props: PageProps) {
   const params = useParams();
-  const [dbTable, setDbTable] = useState("");
   const [sqlConnection, setSqlConnection] = useState<
     SqlType | undefined | void | ""
   >(undefined);
+  const [dbSchema, setDbSchema] = useState("USER");
+  const [dbTable, setDbTable] = useState("");
   const [loginState, setLoginState] = useState<
     "loading" | "login" | "loginWithRegister" | "connected"
   >("loading");
@@ -148,7 +150,6 @@ function SqlPage(props: PageProps) {
   }
 
   useEffect(() => {
-    loadTables(true);
     tryDbaasLogin().then((sqlConnection: SqlType | undefined | void | "") => {
       if (sqlConnection) {
         setSqlConnection(sqlConnection);
@@ -159,31 +160,38 @@ function SqlPage(props: PageProps) {
     });
   }, []);
 
-  async function loadTables(useCache: boolean): Promise<MenuItemProps[]> {
+  useEffect(() => {
+    loadSchemas();
+  }, [sqlConnection]);
+
+  useEffect(() => {
+    loadTables();
+  }, [dbSchema, sqlConnection]);
+
+  async function loadTables(): Promise<MenuItemProps[]> {
     if (!sqlConnection) {
       return new Promise((resolve) => resolve([]));
     }
-    if (!useCache || !tablesCache) {
-      tablesCache = [];
-      const results = await sqlConnection.runCommand("EXECUTE_QUERY", [
-        "SELECT tablename FROM system.tables where type = 'TABLE' and schema = '" +
-          sqlConnection.getDefaultSchema() +
-          "'",
-      ]);
-      if (results.error) {
-        Toast.show(results.error, results);
-        setDbTable("");
-      } else if (results.rows) {
-        tablesCache = results.rows.map((row) => row.values[0]);
-        if (!tablesCache.includes(dbTable)) {
-          if (tablesCache.length > 0) {
-            setDbTable(tablesCache[0]);
-          } else {
-            setDbTable("");
-          }
+    tablesCache = [];
+    const results = await sqlConnection.runCommand("EXECUTE_QUERY", [
+      "SELECT tablename FROM system.tables where type = 'TABLE' and schema = '" +
+        dbSchema +
+        "'",
+    ]);
+    if (results.error) {
+      Toast.show(results.error, results);
+      setDbTable("");
+    } else if (results.rows) {
+      tablesCache = results.rows.map((row) => row.values[0]);
+      if (!tablesCache.includes(dbTable)) {
+        if (tablesCache.length > 0) {
+          setDbTable(tablesCache[0]);
+        } else {
+          setDbTable("");
         }
       }
     }
+
     return new Promise((resolve) =>
       resolve(
         (tablesCache || []).map((table) => {
@@ -192,6 +200,48 @@ function SqlPage(props: PageProps) {
             label: table,
             onClick: () => {
               setDbTable(table);
+              return true;
+            },
+          };
+        }),
+      ),
+    );
+  }
+
+  async function loadSchemas(): Promise<MenuItemProps[]> {
+    if (!sqlConnection) {
+      return new Promise((resolve) => resolve([]));
+    }
+
+    const results = await sqlConnection.runCommand("EXECUTE_QUERY", [
+      "SELECT schema FROM system.schemas",
+    ]);
+    if (results.error) {
+      Toast.show(results.error, results);
+      setDbSchema("USER");
+    } else if (results.rows) {
+      schemasCache = results.rows.map((row) => row.values[0]);
+      schemasCache = schemasCache.filter(
+        (schema) => schema.toUpperCase() !== "SYSTEM",
+      );
+      if (!schemasCache.includes("USER")) {
+        schemasCache.push("USER");
+      }
+      if (!schemasCache.includes(dbSchema)) {
+        schemasCache.push(dbSchema);
+      }
+    }
+
+    return new Promise((resolve) =>
+      resolve(
+        (schemasCache || []).map((schema) => {
+          return {
+            id: schema,
+            label: schema,
+            onClick: () => {
+              setDbSchema(schema);
+              loadTables();
+              sqlConnection.setDefaultSchema(schema);
               return true;
             },
           };
@@ -244,6 +294,33 @@ function SqlPage(props: PageProps) {
     }
   }
 
+  const breadCrumbs = [
+    params.organization,
+    params.project,
+    params.database,
+  ].map((name) => {
+    return (
+      <Typography
+        color="text.primary"
+        style={{ fontSize: "1em", textWrap: "nowrap" }}
+      >
+        {name}
+      </Typography>
+    );
+  });
+  if (sqlConnection) {
+    breadCrumbs.push(
+      <ComboBox loadItems={loadSchemas} selected={dbSchema}>
+        <label>{dbSchema}</label>
+      </ComboBox>,
+    );
+    breadCrumbs.push(
+      <ComboBox loadItems={loadTables} selected={dbTable}>
+        <label>{dbTable}</label>
+      </ComboBox>,
+    );
+  }
+
   return (
     <PageLayout {...props}>
       <div className="NuoListResourceHeader">
@@ -267,23 +344,7 @@ function SqlPage(props: PageProps) {
               flexWrap: "nowrap",
             }}
           >
-            {[params.organization, params.project, params.database].map(
-              (name) => {
-                return (
-                  <Typography
-                    color="text.primary"
-                    style={{ fontSize: "1em", textWrap: "nowrap" }}
-                  >
-                    {name}
-                  </Typography>
-                );
-              },
-            )}
-            {(sqlConnection && (
-              <ComboBox loadItems={loadTables} selected={dbTable}>
-                <label>{dbTable}</label>
-              </ComboBox>
-            )) || <div></div>}
+            {breadCrumbs}
           </StyledBreadcrumbs>
           <div className="NuoRight">
             {(sqlConnection as SqlType)?.getDbUsername() && (

--- a/ui/src/components/pages/sql/SqlLogin.tsx
+++ b/ui/src/components/pages/sql/SqlLogin.tsx
@@ -19,7 +19,6 @@ function SqlLogin({ setSqlConnection, showRegistration }: SqlLoginProps) {
   const params = useParams();
   const [dbUsername, setDbUsername] = useState("");
   const [dbPassword, setDbPassword] = useState("");
-  const [dbSchema, setDbSchema] = useState("");
   const [error, setError] = useState<string | undefined>("");
   const [showRegisterUserDialog, setShowRegisterUserDialog] = useState(false);
 
@@ -93,16 +92,6 @@ function SqlLogin({ setSqlConnection, showRegistration }: SqlLoginProps) {
           ) => setDbPassword(event.currentTarget.value)}
         />
       </div>
-      <div className="NuoFieldContainer">
-        <TextField
-          id="dbSchema"
-          label={t("form.sqleditor.label.dbSchema")}
-          value={dbSchema}
-          onChange={(
-            event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
-          ) => setDbSchema(event.currentTarget.value)}
-        />
-      </div>
       <div className="NuoFieldContainer NuoButtons">
         <Button
           data-testid="sql.login.button"
@@ -113,14 +102,13 @@ function SqlLogin({ setSqlConnection, showRegistration }: SqlLoginProps) {
               params.project &&
               params.database &&
               dbUsername &&
-              dbPassword &&
-              dbSchema
+              dbPassword
             ) {
               const conn = SqlSocket(
                 params.organization,
                 params.project,
                 params.database,
-                dbSchema,
+                "USER",
                 dbUsername,
                 dbPassword,
               );

--- a/ui/src/components/pages/sql/SqlQueryTab.tsx
+++ b/ui/src/components/pages/sql/SqlQueryTab.tsx
@@ -8,11 +8,12 @@ import {
   SqlResponse,
   SqlType,
 } from "../../../utils/SqlSocket";
-import TextField from "../../controls/TextField";
 import Button from "../../controls/Button";
 import SqlResultsRender from "./SqlResultsRender";
 import Toast from "../../controls/Toast";
 import Pagination, { pageFilter } from "../../controls/Pagination";
+import CodeMirror, { EditorView } from "@uiw/react-codemirror";
+import { sql } from "@codemirror/lang-sql";
 
 type SqlQueryTabProps = {
   sqlConnection: SqlType;
@@ -42,17 +43,20 @@ function SqlQueryTab({ sqlConnection, dbTable }: SqlQueryTabProps) {
   return (
     <>
       <form>
-        <div className="NuoRow NuoFieldContainer">
-          <TextField
-            disabled={!sqlConnection || executing}
-            required
+        <div className="NuoRow NuoFieldContainer" style={{ gap: "5px" }}>
+          <CodeMirror
+            className="NuoRow"
             data-testid="sqlQuery"
             id="sqlQuery"
-            label="SQL Query"
             value={sqlQuery}
-            onChange={(
-              event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
-            ) => setSqlQuery(event.target.value)}
+            width="100%"
+            height="200px"
+            style={{ overflow: "auto" }}
+            extensions={[
+              sql(),
+              EditorView.editable.of(sqlConnection && !executing),
+            ]}
+            onChange={(value) => setSqlQuery(value)}
           />
           <Button
             data-testid="submitSql"

--- a/ui/src/utils/SqlSocket.ts
+++ b/ui/src/utils/SqlSocket.ts
@@ -61,6 +61,7 @@ export type SqlType = {
     timeout?: number,
   ) => Promise<SqlResponse>;
   getDefaultSchema: () => string;
+  setDefaultSchema: (schema_: string) => void;
   sqlImport: (
     file: File,
     progressKey: string,
@@ -115,8 +116,12 @@ export default function SqlSocket(
     }
   }
 
-  function getDefaultSchema() {
+  function getDefaultSchema(): string {
     return schema;
+  }
+
+  function setDefaultSchema(schema_: string) {
+    schema = schema_;
   }
 
   function getOrgProjDbSchemaUrl() {
@@ -198,6 +203,7 @@ export default function SqlSocket(
   return {
     runCommand,
     getDefaultSchema,
+    setDefaultSchema,
     sqlImport,
     sqlSimpleImport,
     getDbUsername,


### PR DESCRIPTION
- reduce login page to just `db user name` and `password` (eliminate `schema` field)
- add `schema` combo box to breadcrumb
- replace simple text field with SQL editor (syntax highlighting + multi-line)