### PR TITLE
add jdbc URL field in database info dialog

### DIFF
--- a/ui/src/components/pages/custom/DbConnectionInfo.tsx
+++ b/ui/src/components/pages/custom/DbConnectionInfo.tsx
@@ -83,6 +83,14 @@ export default function DbConnectionInfo({ data, t }: DbConnectionInfoProps) {
     "}",
   ];
 
+  const jdbcUrl =
+    "jdbc:com.nuodb://" +
+    encodeURIComponent(sqlEndpoint) +
+    ":443/" +
+    encodeURIComponent(dbName) +
+    "?trustedCertificates=" +
+    encodeURIComponent(caPem);
+
   const jdbcSh = [
     'echo "' + caPem + '" > ' + dbName + ".pem",
     'keytool -import -trustcacerts -alias "' +
@@ -274,6 +282,7 @@ export default function DbConnectionInfo({ data, t }: DbConnectionInfoProps) {
 
   return (
     <div className="NuoDbConnectionInfo">
+      {renderCopyField(t("dialog.dbConnectionInfo.label.databaseUrl"), jdbcUrl)}
       {renderCopyField(t("dialog.dbConnectionInfo.label.database"), dbName)}
       {renderCopyField(
         t("dialog.dbConnectionInfo.label.sqlEndpoint"),

--- a/ui/src/components/pages/parts/Dialog.tsx
+++ b/ui/src/components/pages/parts/Dialog.tsx
@@ -139,7 +139,12 @@ export default class Dialog extends Component<
   render() {
     return this.state.dialogs.map((dialog: DialogProps, index: number) => {
       return (
-        <DialogMaterial key={index} maxWidth={dialog.maxWidth} open={true}>
+        <DialogMaterial
+          key={index}
+          maxWidth={dialog.maxWidth}
+          fullWidth={dialog.maxWidth === "xl"}
+          open={true}
+        >
           <DialogTitle>{dialog.title}</DialogTitle>
           {dialog.buttons.length > 0 ? (
             <>

--- a/ui/src/resources/translation/en.json
+++ b/ui/src/resources/translation/en.json
@@ -339,6 +339,7 @@
       "label": {
         "database": "Database",
         "sqlEndpoint": "SQL Endpoint",
+        "databaseUrl": "Database URL",
         "certificate": "Certificate",
         "codeSamples": "Code Samples",
         "description": "Following samples require the NuoDB client library which can be downloaded from [here](https://github.com/nuodb/nuodb-client/releases). Fill in database username + password and run the samples below from within the extracted NuoDB client library directory.",


### PR DESCRIPTION
this will add a JDBC URL informational field to copy for database clients like DBeaver or DbVisualizer. It combines the existing fields (db name, hostname, certificate) into a single unit to copy, so the user doesn't have to construct the JDBC URL manually.