### PR TITLE
auto-login if only one IDP is available

### DIFF
--- a/docker/development/default.conf.template
+++ b/docker/development/default.conf.template
@@ -13,6 +13,15 @@ server {
     alias /usr/share/nginx/html/theme/custom.json;
   }
 
+  location /cas-server/ {
+    proxy_pass http://localhost/cas-server/;
+  }
+
+
+  location /keycloak/ {
+    proxy_pass http://localhost/keycloak/;
+  }
+
   location /nuodb-cp/ {
     proxy_pass %%%NUODB_CP_URL_BASE%%%/;
   }

--- a/selenium-tests/cas-server/main.go
+++ b/selenium-tests/cas-server/main.go
@@ -43,9 +43,9 @@ var loginTmpl = template.Must(template.New("login").Parse(`
 <h2>CAS Login</h2>
 <form method="post" action="/cas-server/login">
   <input type="hidden" name="service" value="{{.Service}}" />
-  <label>Username: <input name="username" /></label><br/>
-  <label>Password: <input type="password" name="password" /></label><br/>
-  <button id="login-button" type="submit">Login</button>
+  <label>Username: <input name="username" data-testid="username"/></label><br/>
+  <label>Password: <input type="password" name="password" data-testid="password" /></label><br/>
+  <button id="login-button" type="submit" data-testid="submit-button">Login</button>
   </form>
 </body></html>
 `))

--- a/selenium-tests/files/nginx-default.conf
+++ b/selenium-tests/files/nginx-default.conf
@@ -12,6 +12,10 @@ server {
     proxy_pass http://localhost:3000/ui/;
   }
 
+  location /cas-server/ {
+    proxy_pass http://localhost/cas-server/;
+  }
+
   location /keycloak/ {
     proxy_pass http://localhost/keycloak/;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/ui-test/basic/error-pages.spec.ts
+++ b/ui-test/basic/error-pages.spec.ts
@@ -50,7 +50,7 @@ test.describe("ErrorPagesTest", () => {
     await page.goto(url);
     await page.getByTestId("show_login_button").waitFor({ state: "visible" });
     const expectedUrl = new URL(
-      `/ui/login?redirectUrl=${encodeURIComponent("http://localhost" + url)}`,
+      `/ui/login?redirectUrl=${encodeURIComponent("http://localhost" + url) + "&autoLogin=true"}`,
       page.url(),
     );
     expect(page.url()).toBe(expectedUrl.toString());

--- a/ui-test/basic/error-pages.spec.ts
+++ b/ui-test/basic/error-pages.spec.ts
@@ -50,7 +50,7 @@ test.describe("ErrorPagesTest", () => {
     await page.goto(url);
     await page.getByTestId("show_login_button").waitFor({ state: "visible" });
     const expectedUrl = new URL(
-      `/ui/login?redirect=${encodeURIComponent(url)}`,
+      `/ui/login?redirectUrl=${encodeURIComponent("http://localhost" + url)}`,
       page.url(),
     );
     expect(page.url()).toBe(expectedUrl.toString());

--- a/ui-test/login.spec.ts
+++ b/ui-test/login.spec.ts
@@ -63,6 +63,29 @@ test.describe("LoginTest", () => {
     await expect(btnSimple).toHaveText("Login With CAS Simple");
   });
 
+  test("testIdp – Login via CAS IdP", async ({ page }) => {
+    await page.goto("/ui/login");
+    const btnSimple = page.getByTestId("login_cas-simple");
+    await expect(btnSimple).toBeVisible();
+    await expect(btnSimple).toHaveText("Login With CAS Simple");
+    await btnSimple.click();
+    await page.getByTestId("username").fill("user1");
+    await page.getByTestId("password").fill("passw0rd");
+    await page.getByTestId("submit-button").click();
+    await page.getByTestId("user-menu").click();
+    await page.getByTestId("logout").click();
+    await expect(page.getByTestId("show_login_button")).toBeVisible();
+  });
+
+  test("testIdp – Login DIRECTLY via CAS IdP", async ({ page }) => {
+    await page.goto("/ui/login?autoLogin=cas-simple");
+    await page.getByTestId("username").fill("user1");
+    await page.getByTestId("password").fill("passw0rd");
+    await page.getByTestId("submit-button").click();
+    await page.getByTestId("user-menu").click();
+    await page.getByTestId("logout").click();
+  });
+
   test("testNonExistentIdp – unknown provider shows error", async ({
     page,
   }) => {

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -202,7 +202,7 @@ function App({ t }: { t: TFunction }) {
                     <Navigate
                       to={
                         "/ui/login?redirectUrl=" +
-                        encodeURIComponent(window.location.href)
+                        encodeURIComponent(window.location.href) + "&autoLogin=true"
                       }
                     />
                   }

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -201,8 +201,8 @@ function App({ t }: { t: TFunction }) {
                   element={
                     <Navigate
                       to={
-                        "/ui/login?redirect=" +
-                        encodeURIComponent(window.location.pathname)
+                        "/ui/login?redirectUrl=" +
+                        encodeURIComponent(window.location.href)
                       }
                     />
                   }

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -202,7 +202,8 @@ function App({ t }: { t: TFunction }) {
                     <Navigate
                       to={
                         "/ui/login?redirectUrl=" +
-                        encodeURIComponent(window.location.href) + "&autoLogin=true"
+                        encodeURIComponent(window.location.href) +
+                        "&autoLogin=true"
                       }
                     />
                   }

--- a/ui/src/components/pages/LoginForm.tsx
+++ b/ui/src/components/pages/LoginForm.tsx
@@ -48,11 +48,9 @@ function LoginForm({ setIsLoggedIn, t }: Props) {
   const redirectUrl =
     window.location.origin +
     "/ui/login?provider={name}&redirectUrl=" +
-    new URL(
-      queryParams.get("redirect") || queryParams.get("redirectUrl") || "",
-      window.location.origin,
-    ).href;
-
+    encodeURIComponent(
+      queryParams.get("redirectUrl") || window.location.origin + "/ui",
+    );
   useEffect(() => {
     handleInitialLoad();
   }, []);
@@ -74,7 +72,19 @@ function LoginForm({ setIsLoggedIn, t }: Props) {
         loginFailed(error);
       }
     } else {
-      fetchProviders();
+      const providers = await fetchProviders();
+      const autoLogin = urlParams.get("autoLogin");
+      if (providers && providers.length > 0 && autoLogin) {
+        let provider = undefined;
+        if (autoLogin === "true" && providers.length === 1) {
+          provider = providers[0];
+        } else {
+          provider = providers.find((provider) => provider.name === autoLogin);
+        }
+        if (provider?.url) {
+          window.location.href = provider.url;
+        }
+      }
       fetchAuthHeader();
     }
   }
@@ -85,10 +95,24 @@ function LoginForm({ setIsLoggedIn, t }: Props) {
         `/login/providers?redirectUrl=${encodeURIComponent(redirectUrl)}`,
       )) as ProvidersResponse | undefined;
       if (data?.items) {
-        setProviders(data.items);
+        setProviders(
+          data.items.map((provider) => {
+            if (provider.url) {
+              //replace hard coded keycloak URL with origin
+              provider.url = provider.url.replaceAll(
+                "http://ingress-nginx-controller.ingress-nginx.svc.cluster.local",
+                window.location.origin,
+              );
+            }
+            return provider;
+          }),
+        );
+        return data.items;
       }
+      return [];
     } catch (err: any) {
       console.error("Failed to fetch providers", err);
+      return undefined;
     }
   }
 
@@ -133,8 +157,11 @@ function LoginForm({ setIsLoggedIn, t }: Props) {
         accessRule: data.accessRule,
       }),
     );
-    const redirect = queryParams.get("redirectUrl") || "/ui";
-    window.location.href = isSafeRedirect(redirect) ? redirect : "/ui";
+    const redirectUrl =
+      queryParams.get("redirectUrl") || window.location.origin + "/ui";
+    window.location.href = isSafeRedirect(redirectUrl)
+      ? redirectUrl
+      : window.location.origin + "/ui";
   }
 
   function loginFailed(err: any) {
@@ -155,7 +182,7 @@ function LoginForm({ setIsLoggedIn, t }: Props) {
     const err = await Auth.login(`${organization}/${username}`, password);
     if (!err) {
       setIsLoggedIn(true);
-      navigate(searchParams.get("redirect") || "/ui");
+      navigate(searchParams.get("redirectUrl") || "/ui");
     } else {
       loginFailed(err);
     }
@@ -289,9 +316,12 @@ function LoginForm({ setIsLoggedIn, t }: Props) {
                 key={provider.name}
                 data-testid={`login_${provider.name}`}
                 variant="contained"
-                onClick={() =>
-                  (window.location.href = `${provider.url}&redirectUrl=${encodeURIComponent(redirectUrl)}`)
-                }
+                onClick={() => {
+                  if (!provider.url) {
+                    return;
+                  }
+                  window.location.href = `${provider.url}&redirectUrl=${encodeURIComponent(redirectUrl)}`;
+                }}
               >
                 {t("form.login.label.loginWith", {
                   providerDesc: provider.description,

--- a/ui/src/components/pages/LoginForm.tsx
+++ b/ui/src/components/pages/LoginForm.tsx
@@ -42,7 +42,6 @@ function LoginForm({ setIsLoggedIn, t }: Props) {
   const [error, setError] = useState("");
   const [providers, setProviders] = useState<Provider[] | undefined>(undefined);
   const [progressMessage, setProgressMessage] = useState("");
-  const [authHeader, setAuthHeader] = useState("");
   const [showLoginForm, setShowLoginForm] = useState(false);
   // Specify redirect URL so that provider name is supplied as query parameter
   const redirectUrl =
@@ -72,47 +71,54 @@ function LoginForm({ setIsLoggedIn, t }: Props) {
         loginFailed(error);
       }
     } else {
-      const providers = await fetchProviders();
+      const hasBasicAndProviders = await Promise.all([
+        fetchHasBasicAuth(),
+        fetchProviders(),
+      ]);
+      const basicProviders = hasBasicAndProviders[0]
+        ? [{ name: "basic", description: "", url: "" }]
+        : [];
+      const idpProviders = hasBasicAndProviders[1];
       const autoLogin = urlParams.get("autoLogin");
-      if (providers && providers.length > 0 && autoLogin) {
+      if (idpProviders.length > 0 && autoLogin) {
         let provider = undefined;
-        if (autoLogin === "true" && providers.length === 1) {
-          provider = providers[0];
+        if (autoLogin === "true" && idpProviders.length === 1) {
+          provider = idpProviders[0];
         } else {
-          provider = providers.find((provider) => provider.name === autoLogin);
+          provider = idpProviders.find(
+            (provider) => provider.name === autoLogin,
+          );
         }
         if (provider?.url) {
           window.location.href = provider.url;
+          return;
         }
       }
-      fetchAuthHeader();
+      setProviders([...basicProviders, ...idpProviders]);
     }
   }
 
-  async function fetchProviders() {
+  async function fetchProviders(): Promise<Provider[]> {
     try {
       const data = (await Rest.get(
         `/login/providers?redirectUrl=${encodeURIComponent(redirectUrl)}`,
       )) as ProvidersResponse | undefined;
       if (data?.items) {
-        setProviders(
-          data.items.map((provider) => {
-            if (provider.url) {
-              //replace hard coded keycloak URL with origin
-              provider.url = provider.url.replaceAll(
-                "http://ingress-nginx-controller.ingress-nginx.svc.cluster.local",
-                window.location.origin,
-              );
-            }
-            return provider;
-          }),
-        );
-        return data.items;
+        return data.items.map((provider) => {
+          if (provider.url) {
+            //replace hard coded keycloak URL with origin
+            provider.url = provider.url.replaceAll(
+              "http://ingress-nginx-controller.ingress-nginx.svc.cluster.local",
+              window.location.origin,
+            );
+          }
+          return provider;
+        });
       }
       return [];
     } catch (err: any) {
       console.error("Failed to fetch providers", err);
-      return undefined;
+      return [];
     }
   }
 
@@ -121,7 +127,7 @@ function LoginForm({ setIsLoggedIn, t }: Props) {
    * and then capture the www-authenticate header from the response.
    * Ensure that the auth Header contains the "Basic" authentication method to render local login form.
    * */
-  async function fetchAuthHeader() {
+  async function fetchHasBasicAuth(): Promise<boolean> {
     try {
       await axios.post(
         Auth.getNuodbCpRestUrl("login"),
@@ -133,9 +139,13 @@ function LoginForm({ setIsLoggedIn, t }: Props) {
       );
     } catch (error: any) {
       if (error.response?.headers["www-authenticate"]) {
-        setAuthHeader(error.response.headers["www-authenticate"]);
+        return error.response.headers["www-authenticate"]
+          .split(",")
+          .map((part: string) => part.trim().toLowerCase())
+          .includes("basic");
       }
     }
+    return false;
   }
 
   function isSafeRedirect(url: string): boolean {
@@ -293,20 +303,23 @@ function LoginForm({ setIsLoggedIn, t }: Props) {
   function renderLoginButtons() {
     return (
       <>
-        {authHeader.split(",").includes("Basic") && !showLoginForm && (
-          <Button
-            data-testid="show_login_button"
-            variant="contained"
-            onClick={() => setShowLoginForm(true)}
-          >
-            {t("form.login.label.login")}
-          </Button>
-        )}
+        {providers &&
+          providers.find((provider) => provider.name === "basic") &&
+          !showLoginForm && (
+            <Button
+              data-testid="show_login_button"
+              variant="contained"
+              onClick={() => setShowLoginForm(true)}
+            >
+              {t("form.login.label.login")}
+            </Button>
+          )}
 
         {providers &&
           providers
             .filter(
               (provider) =>
+                provider.name !== "basic" &&
                 provider.description &&
                 (provider.url?.toLowerCase().startsWith("https://") || //prevents XSS by preventing a "javascript:" URL
                   provider.url?.toLowerCase().startsWith("http://")),

--- a/ui/src/components/pages/parts/Banner.tsx
+++ b/ui/src/components/pages/parts/Banner.tsx
@@ -98,7 +98,7 @@ function Banner(props: Props) {
                 "data-testid": "logout",
                 onClick: () => {
                   Auth.logout();
-                  window.location.href = "/ui";
+                  window.location.href = "/ui/login";
                   return true;
                 },
               },

--- a/ui/src/components/pages/parts/Rest.tsx
+++ b/ui/src/components/pages/parts/Rest.tsx
@@ -347,13 +347,7 @@ export class Rest extends React.Component<{
             headers: Auth.getHeaders(),
           })
           .catch((error2) => {
-            if (error2.response.status === 401) {
-              Auth.logout();
-              window.location.href =
-                "/ui/login?redirect=" +
-                encodeURIComponent(window.location.href);
-              return true;
-            }
+            return Auth.handle401Error(error2);
           });
       }
     }

--- a/ui/src/utils/auth.ts
+++ b/ui/src/utils/auth.ts
@@ -311,14 +311,17 @@ export default class Auth {
     }
   }
 
-  static handle401Error(error: TempAny) {
+  static handle401Error(error: TempAny): boolean {
     if (error.response && error.response.status === 401) {
       Auth.logout();
       if (isBrowser()) {
         window.location.href =
-          "/ui/login?redirect=" + encodeURIComponent(window.location.pathname);
+          "/ui/login?autoLogin=true&redirectUrl=" +
+          encodeURIComponent(window.location.href);
+        return true;
       }
     }
+    return false;
   }
 
   static getAccessRule(): { allow: string[]; deny: string[] } {


### PR DESCRIPTION
this change will automatically redirect a user to the IDP if only one is configured without going through the login screen and potentially re-authenticate without a login prompt at the IDP if the user is already authenticated at the IDP. This is only effective if there is only one IDP configured.

Architecture:
- if user is not authenticated and accessing a resource requiring authentication, it will redirect to `/ui/login?autoLogin=true&redirectUrl=<absolute URL of current resource>`
- on `/ui/login` page, if `autoLogin=true` is set, it will check if only one IDP exists and redirect to that IDP for authentication
- `autologin` is set to a different value, it will redirect to the given IDP if it exists
- otherwise it shows the login page with the available IDP's and local login option

Additional changes:
- combined `redirect=` and `redirectUrl=` url parameters into `redirectUrl=` parameter
- `redirectUrl=` will now contain an absolute URL all the time
- added keycloak / cas redirects for development testing
- added integration tests
