### PR TITLE
fix race condition of /ui/error redirect and 401 redirect

### DIFF
--- a/ui/src/components/pages/parts/Schema.tsx
+++ b/ui/src/components/pages/parts/Schema.tsx
@@ -10,13 +10,9 @@ export default function Schema({ setSchema }: TempAny) {
 
   useEffect(() => {
     getSchema().then((schema) => {
-      if (!schema && window.location.pathname !== "/ui/error") {
-        navigate(
-          "/ui/error?msg=" +
-            encodeURIComponent("Unable to get Schema. Retry at a later time."),
-        );
+      if (schema) {
+        setSchema(schema);
       }
-      setSchema(schema);
     });
   }, [setSchema, navigate]);
 

--- a/ui/src/utils/auth.ts
+++ b/ui/src/utils/auth.ts
@@ -311,14 +311,16 @@ export default class Auth {
     }
   }
 
-  static handle401Error(error: TempAny) {
+  static handle401Error(error: TempAny): boolean {
     if (error.response && error.response.status === 401) {
       Auth.logout();
       if (isBrowser()) {
         window.location.href =
           "/ui/login?redirect=" + encodeURIComponent(window.location.pathname);
       }
+      return true;
     }
+    return false;
   }
 
   static getAccessRule(): { allow: string[]; deny: string[] } {

--- a/ui/src/utils/schema.ts
+++ b/ui/src/utils/schema.ts
@@ -12,6 +12,7 @@ import {
   DataType,
 } from "./types";
 import { getValue } from "../components/fields/utils";
+import Toast from "../components/controls/Toast";
 let schema: TempAny = null;
 
 /**
@@ -34,8 +35,10 @@ export async function getSchema() {
       schema = schema["paths"];
       schema = filterAccessPaths(schema);
     } catch (error) {
-      console.log("ERROR", error);
-      Auth.handle401Error(error);
+      if (!Auth.handle401Error(error)) {
+        console.log("ERROR", error);
+        Toast.show("Unable to get schema", error);
+      }
     }
   }
   return schema;


### PR DESCRIPTION
fix race condition where an un-authenticated user tries to login to 3rd party IDP provider while also redirecting to an error page during initial schema load.
Fix prevents the secondary navigation to the `/ui/error` page if schema returns a 401. For other errors it sends a message on the top of the browser window.